### PR TITLE
Add information to logs with a custom runner

### DIFF
--- a/src/array/dune
+++ b/src/array/dune
@@ -19,7 +19,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests)
@@ -32,7 +32,7 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -43,4 +43,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -22,7 +22,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 
 ;; Linearizability tests of Atomic, utilizing ppx_deriving_qcheck
@@ -38,7 +38,7 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -49,4 +49,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -25,5 +25,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -17,4 +17,4 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -25,12 +25,10 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -19,7 +19,7 @@
  (alias runtest)
  (package multicoretests)
  (deps domain_joingraph.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name domain_spawntree)
@@ -31,4 +31,4 @@
  (alias runtest)
  (deps domain_spawntree.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -22,7 +22,7 @@
  (alias runtest)
  (package multicoretests)
  (deps task_one_dep.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name task_more_deps)
@@ -34,7 +34,7 @@
  (alias runtest)
  (deps task_more_deps.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name task_parallel)
@@ -45,7 +45,7 @@
  (alias runtest)
  (package multicoretests)
  (deps task_parallel.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 
 ;; STM_seq and STM_domain test of Domainslib.Chan
@@ -59,4 +59,4 @@
 (rule
  (alias runtest)
  (deps chan_stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/ephemeron/dune
+++ b/src/ephemeron/dune
@@ -15,7 +15,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -26,4 +26,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/floatarray/dune
+++ b/src/floatarray/dune
@@ -18,8 +18,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -30,5 +29,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -19,7 +19,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests)
@@ -32,7 +32,7 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -43,4 +43,4 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -15,7 +15,7 @@
  (alias runtest)
  (deps util_print_test.exe)
  (package multicoretests)
- (action (run ./%{deps})))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 
 (executable
@@ -28,4 +28,4 @@
  (alias runtest)
  (deps cleanup.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -19,7 +19,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests)
@@ -31,7 +31,7 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_dsl)
@@ -42,4 +42,4 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests_dsl.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -18,4 +18,4 @@
  (alias runtest)
  (package multicoretests)
  (deps ws_deque_test.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -45,19 +45,19 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests_sequential_ref.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps stm_tests_domain_ref.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps stm_tests_thread_ref.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (library
  (name CList)
@@ -73,7 +73,7 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests_conclist.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 
 ;; Linearizability tests of ref and Clist
@@ -112,19 +112,19 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl_domain.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 ; (rule
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests_dsl_thread.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl_effect.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests_domain)
@@ -149,22 +149,22 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests_domain.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_thread_ref.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (rule
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_thread_conclist.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 ; (rule
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests_effect.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -18,7 +18,7 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests)
@@ -31,4 +31,4 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# A runner for tests that adds timestamps and, in CI, anchors in logs
+# All lines end as comments since bash on Windows CI seems to conjure
+# some '\r' it doesn’t like into existence
+test="$1"                                                                                                     #
+warning() {                                                                                                   #
+if [ "$CI" = true ] ; then                                                                                    #
+  printf '\n::warning title=%s in %s/%s::%s in src/%s/%s' "$1" "${PWD##*/}" "$test" "$1" "${PWD##*/}" "$test" #
+else                                                                                                          #
+  printf '\nWarning: %s in src/%s/%s' "$1" "${PWD##*/}" "$test"                                               #
+fi                                                                                                            #
+}                                                                                                             #
+error() {                                                                                                     #
+if [ "$CI" = true ] ; then                                                                                    #
+  printf '\n::error title=%s in %s/%s::%s in src/%s/%s' "$1" "${PWD##*/}" "$test" "$1" "${PWD##*/}" "$test"   #
+else                                                                                                          #
+  printf '\nError: %s in src/%s/%s' "$1" "${PWD##*/}" "$test"                                                 #
+fi                                                                                                            #
+}                                                                                                             #
+                                                                                                              #
+if [[ "$2" = "" ]] ; then                                                                                     #
+  printf '\n\nStarting "./%s --verbose" in %s\n' "$test" "${PWD##*/}"                                         #
+  ./"$test" --verbose                                                                                         #
+  result="$?"                                                                                                 #
+else                                                                                                          #
+  shift                                                                                                       #
+  printf '\n\nStarting "./%s %s" in %s\n' "$test" "$*" "${PWD##*/}"                                           #
+  ./"$test" "$@"                                                                                              #
+  result="$?"                                                                                                 #
+fi                                                                                                            #
+case "$result" in                                                                                             #
+  0)                                                                                                          #
+    exit 0                                                                                                    #
+    ;;                                                                                                        #
+  1)                                                                                                          #
+    warning "Test failure"                                                                                    #
+    exit 1                                                                                                    #
+    ;;                                                                                                        #
+  139)                                                                                                        #
+    error SIGSEGV                                                                                             #
+    kill -SIGSEGV $$                                                                                          #
+    ;;                                                                                                        #
+  135)                                                                                                        #
+    error SIGBUS                                                                                              #
+    kill -SIGBUS $$                                                                                           #
+    ;;                                                                                                        #
+  137)                                                                                                        #
+    error SIGKILL                                                                                             #
+    kill -SIGKILL $$                                                                                          #
+    ;;                                                                                                        #
+  134)                                                                                                        #
+    error SIGABRT                                                                                             #
+    kill -SIGABRT $$                                                                                          #
+    ;;                                                                                                        #
+  *)                                                                                                          #
+    error "$result"                                                                                           #
+    exit "$result"                                                                                            #
+    ;;                                                                                                        #
+esac                                                                                                          #

--- a/src/semaphore/dune
+++ b/src/semaphore/dune
@@ -16,4 +16,4 @@
  (alias runtest)
  (package multicoretests)
  (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -18,7 +18,7 @@
  (alias runtest)
  (package multicoretests)
  (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name lin_tests)
@@ -31,5 +31,5 @@
 ;  (alias runtest)
 ;  (package multicoretests)
 ;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+;  (action (bash "%{dep:../runner.sh} %{deps}")))
 

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -19,7 +19,7 @@
  (alias runtest)
  (package multicoretests)
  (deps thread_joingraph.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))
 
 (executable
  (name thread_createtree)
@@ -31,4 +31,4 @@
  (alias runtest)
  (deps thread_createtree.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))

--- a/src/threadomain/dune
+++ b/src/threadomain/dune
@@ -16,4 +16,4 @@
  (alias runtest)
  (package multicoretests)
  (deps threadomain.exe)
- (action (run ./%{deps} --verbose)))
+ (action (bash "%{dep:../runner.sh} %{deps}")))


### PR DESCRIPTION
Add a bash script to use as runner for our test suite

This script adds information to the logs:
- explicit names of the test run when they start
- some explicit messages for crashes (SIGSEGV, SIGBUS, ...)
- and, maybe most importantly, anchors in CI logs, so that the main webpage contains the most important information and direct links to precise points of interest in the log

It is written as a bash script but making sure it can be used as a runner also on Windows CI (notably by commenting all ends of lines, without which it fails with errors about '\r's that don't exist...)

Example of result of the changes: the webpage for this [run](https://github.com/shym/multicoretests/actions/runs/3516624336) shows directly that we got a SEGV in Ephemeron on trunk (windows). Or this [run](https://github.com/shym/multicoretests/actions/runs/3516624338) with SIGABRT in buffers on trunk on macos.