### PR TITLE
Update opam files

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,7 @@
 (name multicoretests)
 (generate_opam_files true)
 
-(source (github jmid/multicoretests))
+(source (github ocaml-multicore/multicoretests))
 (authors "Jan Midtgaard" "Olivier Nicole" "Nicolas Osborne" "Samuel Hym")
 (maintainers "Jan Midtgaard <mail@janmidtgaard.dk>")
 (license BSD-2-clause)

--- a/lib/dune
+++ b/lib/dune
@@ -8,19 +8,19 @@
  (name STM_sequential)
  (public_name qcheck-stm.sequential)
  (modules STM_sequential)
- (libraries qcheck-core STM))
+ (libraries qcheck-core qcheck-stm.stm))
 
 (library
  (name STM_domain)
  (public_name qcheck-stm.domain)
  (modules STM_domain)
- (libraries qcheck-core STM))
+ (libraries qcheck-core qcheck-stm.stm))
 
 (library
  (name STM_thread)
  (public_name qcheck-stm.thread)
  (modules STM_thread)
- (libraries threads qcheck-core STM))
+ (libraries threads qcheck-core qcheck-stm.stm))
 
 (library
  (name lin)

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -17,8 +17,8 @@ tags: [
   "multicore"
   "non-determinism"
 ]
-homepage: "https://github.com/jmid/multicoretests"
-bug-reports: "https://github.com/jmid/multicoretests/issues"
+homepage: "https://github.com/ocaml-multicore/multicoretests"
+bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
@@ -47,7 +47,7 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/jmid/multicoretests.git"
+dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"
 pin-depends: [
   ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]
 ]

--- a/qcheck-lin.opam
+++ b/qcheck-lin.opam
@@ -18,8 +18,8 @@ tags: [
   "parallelism"
   "sequential consistency"
 ]
-homepage: "https://github.com/jmid/multicoretests"
-bug-reports: "https://github.com/jmid/multicoretests/issues"
+homepage: "https://github.com/ocaml-multicore/multicoretests"
+bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
@@ -43,4 +43,4 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/jmid/multicoretests.git"
+dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"

--- a/qcheck-multicoretests-util.opam
+++ b/qcheck-multicoretests-util.opam
@@ -10,8 +10,8 @@ maintainer: ["Jan Midtgaard <mail@janmidtgaard.dk>"]
 authors: ["Jan Midtgaard" "Olivier Nicole" "Nicolas Osborne" "Samuel Hym"]
 license: "BSD-2-clause"
 tags: ["test" "property" "qcheck" "quickcheck" "multicore" "non-determinism"]
-homepage: "https://github.com/jmid/multicoretests"
-bug-reports: "https://github.com/jmid/multicoretests/issues"
+homepage: "https://github.com/ocaml-multicore/multicoretests"
+bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
@@ -34,4 +34,4 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/jmid/multicoretests.git"
+dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"

--- a/qcheck-stm.opam
+++ b/qcheck-stm.opam
@@ -18,8 +18,8 @@ tags: [
   "model-based testing"
   "parallel testing"
 ]
-homepage: "https://github.com/jmid/multicoretests"
-bug-reports: "https://github.com/jmid/multicoretests/issues"
+homepage: "https://github.com/ocaml-multicore/multicoretests"
+bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "2.9"}
   "base-domains"
@@ -43,4 +43,4 @@ build: [
   ]
   ["dune" "install" "-p" name "--create-install-files" name]
 ]
-dev-repo: "git+https://github.com/jmid/multicoretests.git"
+dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"


### PR DESCRIPTION
This PR updates the `dune-project` file to the new repo location and regenerates the `opam` files afterwards.

As a little bonus, it also updates the `lib/dune` file to use library names more consistently:
- some rules were using an internal name `STM` whereas 
- other rules were using public names `qcheck-lin.lin`