### PR TITLE
Add `returning_ t` and constants in Lin DSL

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -410,20 +410,14 @@ module MakeCmd (ApiSpec : Spec) : Internal.CmdSpec = struct
     : type a r. a -> (a, r) Args.args -> t -> r = fun f args state ->
     match args with
     | Ret _ ->
-      (* This happens only if there was a non-function value in the API,
-         which I'm not sure makes sense *)
-      raise (Invalid_argument "apply_f")
+      f
     | Ret_or_exc _ ->
-      (* This happens only if there was a non-function value in the API,
-         which I'm not sure makes sense *)
+      (* A constant value in the API cannot raise an exception *)
       raise (Invalid_argument "apply_f")
     | Ret_ignore _ ->
-      (* This happens only if there was a non-function value in the API,
-         which I'm not sure makes sense *)
-      raise (Invalid_argument "apply_f")
+      ()
     | Ret_ignore_or_exc _ ->
-      (* This happens only if there was a non-function value in the API,
-         which I'm not sure makes sense *)
+      (* A constant value in the API cannot raise an exception *)
       raise (Invalid_argument "apply_f")
     | FnState (Ret _) ->
       f state

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -245,8 +245,8 @@ module Fun = struct
   type (_,_,_) fn =
     | Ret :        ('a, deconstructible, 's, combinable) ty -> ('a, 'a, 's) fn
     | Ret_or_exc : ('a, deconstructible, 's, combinable) ty -> ('a, ('a,exn) result, 's) fn
-    | Ret_ignore : ('a, _, 's, combinable) ty -> ('a, unit, 's) fn
-    | Ret_ignore_or_exc : ('a, _, 's, combinable) ty -> ('a, (unit,exn) result, 's) fn
+    | Ret_ignore : ('a, _, 's, _) ty -> ('a, unit, 's) fn
+    | Ret_ignore_or_exc : ('a, _, 's, _) ty -> ('a, (unit,exn) result, 's) fn
     | Fn : ('a, constructible, 's, _) ty * ('b, 'r, 's) fn -> ('a -> 'b, 'r, 's) fn
 end
 

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -244,11 +244,11 @@ val returning_or_exc :
   ('a, ('a, exn) result, 'b) Fun.fn
 (** [returning_or_exc t] represents a return type of a function that may raise an exception. *)
 
-val returning_ : ('a, 'b, 'c, combinable) ty -> ('a, unit, 'c) Fun.fn
+val returning_ : ('a, 'b, 'c, 'd) ty -> ('a, unit, 'c) Fun.fn
 (** [returning_ t] represents a return type that should be ignored. *)
 
 val returning_or_exc_ :
-  ('a, 'b, 'c, combinable) ty -> ('a, (unit, exn) result, 'c) Fun.fn
+  ('a, 'b, 'c, 'd) ty -> ('a, (unit, exn) result, 'c) Fun.fn
 (** [returning_or_exc_ t] represents a return type that should be ignored of a function
     that may raise an exception. *)
 


### PR DESCRIPTION
The last commit of this series is really there to show what the other two add, but should probably not be included: it is probably wasting time on useless test cases.