### PR TITLE
add missing (package ...) and (public_name ...) annotations

### DIFF
--- a/src/array/dune
+++ b/src/array/dune
@@ -10,7 +10,8 @@
    lin_tests_dsl.exe))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -22,7 +23,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
@@ -35,7 +37,8 @@
 ;  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -13,7 +13,8 @@
 ;; STM_sequential and STM_domain test of Atomic
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -28,7 +29,8 @@
 ;; Linearization tests of Atomic, utilizing ppx_deriving_qcheck
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
@@ -41,7 +43,8 @@
 ;  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -10,12 +10,14 @@
    lin_tests_dsl.exe))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -8,7 +8,8 @@
 
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -10,12 +10,14 @@
 ;; Linearization tests
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain qcheck-lin.thread))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -10,7 +10,8 @@
 ;; Tests of Domain's spawn functionality (non-STM)
 
 (executable
- (name domain_joingraph)
+ (public_name domain_joingraph)
+ (package multicoretests)
  (modules domain_joingraph)
  (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show)))
@@ -22,13 +23,14 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name domain_spawntree)
+ (public_name domain_spawntree)
+ (package multicoretests)
  (modules domain_spawntree)
  (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
- (deps domain_spawntree.exe)
  (package multicoretests)
+ (deps domain_spawntree.exe)
  (action (run ./%{deps} --verbose)))

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -13,7 +13,8 @@
 ;; tests of Domainslib.Task's async functionality (non-STM)
 
 (executable
- (name task_one_dep)
+ (public_name task_one_dep)
+ (package multicoretests)
  (modules task_one_dep)
  (libraries util qcheck-core qcheck-core.runner domainslib)
  (preprocess (pps ppx_deriving.show)))
@@ -25,19 +26,21 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name task_more_deps)
+ (public_name task_more_deps)
+ (package multicoretests)
  (modules task_more_deps)
  (libraries util qcheck-core qcheck-core.runner domainslib)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
- (deps task_more_deps.exe)
  (package multicoretests)
+ (deps task_more_deps.exe)
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name task_parallel)
+ (public_name task_parallel)
+ (package multicoretests)
  (modules task_parallel)
  (libraries util qcheck-core qcheck-core.runner domainslib))
 
@@ -51,12 +54,14 @@
 ;; STM_seq and STM_domain test of Domainslib.Chan
 
 (executable
- (name chan_stm_tests)
+ (public_name chan_stm_tests)
+ (package multicoretests)
  (modules chan_stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain domainslib)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
+ (package multicoretests)
  (deps chan_stm_tests.exe)
  (action (run ./%{deps} --verbose)))

--- a/src/ephemeron/dune
+++ b/src/ephemeron/dune
@@ -3,10 +3,12 @@
 ;; this prevents the tests from running on a default build
 (alias
  (name default)
+ (package multicoretests)
  (deps stm_tests.exe lin_tests_dsl.exe))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -18,7 +20,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain qcheck-lin.thread))
 

--- a/src/floatarray/dune
+++ b/src/floatarray/dune
@@ -8,7 +8,8 @@
  (deps stm_tests.exe lin_tests_dsl.exe))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess
@@ -22,7 +23,8 @@
   (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -10,7 +10,8 @@
    lin_tests_dsl.exe))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -22,7 +23,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
@@ -35,7 +37,8 @@
 ;  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 

--- a/src/internal/dune
+++ b/src/internal/dune
@@ -8,15 +8,15 @@
 
 (test
  (name util_print_test)
- (modules util_print_test)
  (package multicoretests)
+ (modules util_print_test)
  (libraries qcheck-multicoretests-util))
 
 
 (test
  (name cleanup)
- (modules cleanup)
  (package multicoretests)
+ (modules cleanup)
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
  (action (run ./%{test} --verbose)))
@@ -24,8 +24,8 @@
 
 (test
  (name mutable_set_v5)
- (modules mutable_set_v5)
  (package multicoretests)
+ (modules mutable_set_v5)
  (libraries qcheck-stm.sequential)
  (preprocess (pps ppx_deriving.show))
  (action

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -10,7 +10,8 @@
    lin_tests_dsl.exe)) ;; currently not run on CI
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -22,7 +23,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
@@ -34,7 +36,8 @@
 ;  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (libraries qcheck-lin.domain))
 

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -9,7 +9,8 @@
  (deps ws_deque_test.exe))
 
 (executable
- (name ws_deque_test)
+ (public_name ws_deque_test)
+ (package multicoretests)
  (modules ws_deque_test)
  (libraries qcheck-stm.sequential qcheck-stm.domain lockfree)
  (preprocess (pps ppx_deriving.show)))

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -22,22 +22,26 @@
 
 (library
  (name stm_tests_spec_ref)
+ (package multicoretests)
  (modules stm_tests_spec_ref)
  (libraries qcheck qcheck-stm.stm)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
 
 (executable
- (name stm_tests_sequential_ref)
+ (public_name stm_tests_sequential_ref)
+ (package multicoretests)
  (modules stm_tests_sequential_ref)
  (libraries stm_tests_spec_ref qcheck-stm.sequential))
 
 (executable
- (name stm_tests_domain_ref)
+ (public_name stm_tests_domain_ref)
+ (package multicoretests)
  (modules stm_tests_domain_ref)
  (libraries stm_tests_spec_ref qcheck-stm.domain))
 
 (executable
- (name stm_tests_thread_ref)
+ (public_name stm_tests_thread_ref)
+ (package multicoretests)
  (modules stm_tests_thread_ref)
  (libraries stm_tests_spec_ref qcheck-stm.thread))
 
@@ -61,10 +65,12 @@
 
 (library
  (name CList)
+ (package multicoretests)
  (modules CList))
 
 (executable
- (name stm_tests_conclist)
+ (public_name stm_tests_conclist)
+ (package multicoretests)
  (modules stm_tests_conclist)
  (libraries CList qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))
@@ -81,29 +87,34 @@
 
 (library
  (name lin_tests_dsl_common)
+ (package multicoretests)
  (modules lin_tests_dsl_common)
  (libraries CList qcheck-lin.domain))
 
 (library
  (name lin_tests_common)
+ (package multicoretests)
  (modules lin_tests_common)
  (libraries CList qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
 
 (executable
- (name lin_tests_dsl_domain)
+ (public_name lin_tests_dsl_domain)
+ (package multicoretests)
  (modules lin_tests_dsl_domain)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common))
 
 (executable
- (name lin_tests_dsl_thread)
+ (public_name lin_tests_dsl_thread)
+ (package multicoretests)
  (modules lin_tests_dsl_thread)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common qcheck-lin.thread))
 
 (executable
- (name lin_tests_dsl_effect)
+ (public_name lin_tests_dsl_effect)
+ (package multicoretests)
  (modules lin_tests_dsl_effect)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common qcheck-lin.effect))
@@ -127,19 +138,22 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests_domain)
+ (public_name lin_tests_domain)
+ (package multicoretests)
  (modules lin_tests_domain)
  (flags (:standard -w -27))
  (libraries lin_tests_common))
 
 (executables
- (names lin_tests_thread_ref lin_tests_thread_conclist)
+ (public_names lin_tests_thread_ref lin_tests_thread_conclist)
+ (package multicoretests)
  (modules lin_tests_thread_ref lin_tests_thread_conclist)
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.thread))
 
 (executable
- (name lin_tests_effect)
+ (public_name lin_tests_effect)
+ (package multicoretests)
  (modules lin_tests_effect)
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.effect)

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -9,7 +9,8 @@
    lin_tests_dsl.exe))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread))
@@ -21,7 +22,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)

--- a/src/semaphore/dune
+++ b/src/semaphore/dune
@@ -7,7 +7,8 @@
  (deps stm_tests.exe))
 
 (executable
- (name stm_tests)
+ (public_name stm_tests)
+ (package multicoretests)
  (modules stm_tests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show)))

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -9,7 +9,8 @@
    lin_tests_dsl.exe))
 
 (executable
- (name lin_tests_dsl)
+ (public_name lin_tests_dsl)
+ (package multicoretests)
  (modules lin_tests_dsl)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread))
@@ -21,7 +22,8 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name lin_tests)
+ (public_name lin_tests)
+ (package multicoretests)
  (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -10,7 +10,8 @@
 ;; Tests of Domain's spawn functionality (non-STM)
 
 (executable
- (name thread_joingraph)
+ (public_name thread_joingraph)
+ (package multicoretests)
  (modules thread_joingraph)
  (libraries threads qcheck-core util)
  (preprocess (pps ppx_deriving.show)))
@@ -22,13 +23,14 @@
  (action (run ./%{deps} --verbose)))
 
 (executable
- (name thread_createtree)
+ (public_name thread_createtree)
+ (package multicoretests)
  (modules thread_createtree)
  (libraries threads qcheck-core util)
  (preprocess (pps ppx_deriving.show)))
 
 (rule
  (alias runtest)
- (deps thread_createtree.exe)
  (package multicoretests)
+ (deps thread_createtree.exe)
  (action (run ./%{deps} --verbose)))

--- a/src/threadomain/dune
+++ b/src/threadomain/dune
@@ -7,7 +7,8 @@
  (deps threadomain.exe))
 
 (executable
- (name threadomain)
+ (public_name threadomain)
+ (package multicoretests)
  (modules threadomain)
  (libraries util qcheck-core threads)
  (preprocess (pps ppx_deriving.show)))


### PR DESCRIPTION
We are missing package annotations on some of the `dune` rules - which means, e.g., a qcheck-stm installation will try to build src/domainslib executables without the dependencies present.

Adding `(package multicoretests)` on everything is not enough.
For `(executable ...)` stanzas they should be declared with a `(public_name ...)` too.
The PR therefore updates `(name ...)` to `(public_name ...)` on the relevant `(executable ...)` stanzas.