### PR TITLE
Simplify dune rules into (test ...)s and add package annotations

### DIFF
--- a/src/array/dune
+++ b/src/array/dune
@@ -7,40 +7,33 @@
  (deps
    stm_tests.exe
    lin_tests.exe ;; currently not run on CI
-   lin_tests_dsl.exe))
+   lin_tests_dsl.exe)
+)
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests)
  (modules lin_tests)
+ (package multicoretests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/array/%{test} from the test suite\n\n"))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -7,46 +7,37 @@
  (deps
    stm_tests.exe
    lin_tests.exe ;; currently not run on CI
-   lin_tests_dsl.exe))
-
+   lin_tests_dsl.exe)
+)
 
 ;; STM_sequential and STM_domain test of Atomic
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
-
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
 ;; Linearization tests of Atomic, utilizing ppx_deriving_qcheck
 
-(executable
+(test
  (name lin_tests)
  (modules lin_tests)
+ (package multicoretests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/atomic/%{test} from the test suite\n\n"))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -7,23 +7,23 @@
  (package multicoretests)
  (deps
    stm_tests.exe ;; currently not run on CI
-   lin_tests_dsl.exe))
+   lin_tests_dsl.exe)
+)
 
-(executable
- (name lin_tests_dsl)
- (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess
-  (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/bigarray/%{test} from the test suite\n\n"))
+)
+
+(test
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ (package multicoretests)
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -4,17 +4,14 @@
 (alias
  (name default)
  (package multicoretests)
- (deps stm_tests.exe))
+ (deps stm_tests.exe)
+)
 
-
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -9,28 +9,19 @@
 
 ;; Linearization tests
 
-(executable
- (name lin_tests_dsl)
- (modules lin_tests_dsl)
- (libraries qcheck-lin.domain qcheck-lin.thread))
-
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
+ (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess
-  (pps ppx_deriving.show)))
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(rule
- (alias runtest)
+(test
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
  (package multicoretests)
- (deps stm_tests.exe)
- (action
-  (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain qcheck-lin.thread)
+ (action (run %{test} --verbose))
+)

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -4,31 +4,25 @@
 (alias
  (name default)
  (package multicoretests)
- (deps domain_joingraph.exe domain_spawntree.exe))
-
+ (deps domain_joingraph.exe domain_spawntree.exe)
+)
 
 ;; Tests of Domain's spawn functionality (non-STM)
 
-(executable
+(test
  (name domain_joingraph)
  (modules domain_joingraph)
- (libraries util qcheck-core qcheck-core.runner)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps domain_joingraph.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries util qcheck-core qcheck-core.runner)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name domain_spawntree)
  (modules domain_spawntree)
- (libraries util qcheck-core qcheck-core.runner)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
- (deps domain_spawntree.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (libraries util qcheck-core qcheck-core.runner)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/domainslib/dune
+++ b/src/domainslib/dune
@@ -5,58 +5,47 @@
  (name default)
  (package multicoretests)
  (deps
-   chan_stm_tests.exe
    task_one_dep.exe
    task_more_deps.exe
-   task_parallel.exe))
+   task_parallel.exe
+   chan_stm_tests.exe)
+)
 
 ;; tests of Domainslib.Task's async functionality (non-STM)
 
-(executable
+(test
  (name task_one_dep)
  (modules task_one_dep)
- (libraries util qcheck-core qcheck-core.runner domainslib)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps task_one_dep.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries util qcheck-core qcheck-core.runner domainslib)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name task_more_deps)
  (modules task_more_deps)
- (libraries util qcheck-core qcheck-core.runner domainslib)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
- (deps task_more_deps.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (libraries util qcheck-core qcheck-core.runner domainslib)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name task_parallel)
  (modules task_parallel)
- (libraries util qcheck-core qcheck-core.runner domainslib))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps task_parallel.exe)
- (action (run ./%{deps} --verbose)))
-
+ (libraries util qcheck-core qcheck-core.runner domainslib)
+ (action (run %{test} --verbose))
+)
 
 ;; STM_seq and STM_domain test of Domainslib.Chan
 
-(executable
+(test
  (name chan_stm_tests)
  (modules chan_stm_tests)
+ (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain domainslib)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
- (deps chan_stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/ephemeron/dune
+++ b/src/ephemeron/dune
@@ -5,25 +5,19 @@
  (name default)
  (deps stm_tests.exe lin_tests_dsl.exe))
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain qcheck-lin.thread))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain qcheck-lin.thread)
+ (action (run %{test} --verbose))
+)

--- a/src/floatarray/dune
+++ b/src/floatarray/dune
@@ -7,28 +7,19 @@
  (package multicoretests)
  (deps stm_tests.exe lin_tests_dsl.exe))
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess
-  (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action
-  (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -15,7 +15,8 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose)))
+ (action (run %{test} --verbose))
+)
 
 (test
  (name lin_tests)

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -9,38 +9,29 @@
    lin_tests.exe ;; currently not run on CI
    lin_tests_dsl.exe))
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose)))
 
-(executable
+(test
  (name lin_tests)
  (modules lin_tests)
+ (package multicoretests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/hashtbl/%{test} from the test suite\n\n"))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -9,37 +9,30 @@
    stm_tests.exe
    lin_tests_dsl.exe)) ;; currently not run on CI
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests)
  (modules lin_tests)
+ (package multicoretests)
  (libraries qcheck-lin.domain)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (libraries qcheck-lin.domain))
-
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests_dsl.exe)
-;  (action (run ./%{deps} --verbose)))
+ (package multicoretests)
+ (libraries qcheck-lin.domain)
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
+)

--- a/src/lockfree/dune
+++ b/src/lockfree/dune
@@ -8,14 +8,11 @@
  (package multicoretests)
  (deps ws_deque_test.exe))
 
-(executable
+(test
  (name ws_deque_test)
  (modules ws_deque_test)
- (libraries qcheck-stm.sequential qcheck-stm.domain lockfree)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps ws_deque_test.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain lockfree)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -18,153 +18,129 @@
    ;; Lin DSL tests
    lin_tests_dsl_domain.exe
    lin_tests_dsl_effect.exe
-   lin_tests_dsl_thread.exe)) ;; currently not run on CI
+   lin_tests_dsl_thread.exe) ;; currently not run on CI
+)
 
 (library
  (name stm_tests_spec_ref)
  (modules stm_tests_spec_ref)
+ (package multicoretests)
  (libraries qcheck qcheck-stm.stm)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq))
+)
 
-(executable
+(test
  (name stm_tests_sequential_ref)
  (modules stm_tests_sequential_ref)
- (libraries stm_tests_spec_ref qcheck-stm.sequential))
+ (package multicoretests)
+ (libraries stm_tests_spec_ref qcheck-stm.sequential)
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name stm_tests_domain_ref)
  (modules stm_tests_domain_ref)
- (libraries stm_tests_spec_ref qcheck-stm.domain))
+ (package multicoretests)
+ (libraries stm_tests_spec_ref qcheck-stm.domain)
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name stm_tests_thread_ref)
  (modules stm_tests_thread_ref)
- (libraries stm_tests_spec_ref qcheck-stm.thread))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests_sequential_ref.exe)
- (action (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps stm_tests_domain_ref.exe)
- (action (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps stm_tests_thread_ref.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries stm_tests_spec_ref qcheck-stm.thread)
+ (action (run %{test} --verbose))
+)
 
 (library
  (name CList)
- (modules CList))
+ (modules CList)
+ (package multicoretests)
+)
 
-(executable
+(test
  (name stm_tests_conclist)
  (modules stm_tests_conclist)
- (libraries CList qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests_conclist.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries CList qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-
-;; Linearization tests of ref and Clist
-
+;; Linearization tests of ref and Clist with Lin
 
 (library
  (name lin_tests_dsl_common)
  (modules lin_tests_dsl_common)
- (libraries CList qcheck-lin.domain))
+ (package multicoretests)
+ (libraries CList qcheck-lin.domain)
+)
 
 (library
  (name lin_tests_common)
  (modules lin_tests_common)
+ (package multicoretests)
  (libraries CList qcheck-lin.domain)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+)
 
-(executable
+(test
  (name lin_tests_dsl_domain)
  (modules lin_tests_dsl_domain)
+ (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_dsl_common))
+ (libraries lin_tests_dsl_common)
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests_dsl_thread)
  (modules lin_tests_dsl_thread)
+ (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_dsl_common qcheck-lin.thread))
+ (libraries lin_tests_dsl_common qcheck-lin.thread)
+ ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+)
 
-(executable
+(test
  (name lin_tests_dsl_effect)
  (modules lin_tests_dsl_effect)
+ (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_dsl_common qcheck-lin.effect))
+ (libraries lin_tests_dsl_common qcheck-lin.effect)
+ (action (run %{test} --verbose))
+)
 
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_dsl_domain.exe)
- (action (run ./%{deps} --verbose)))
+;; Linearization tests of ref and Clist with Lin.Internal
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests_dsl_thread.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_dsl_effect.exe)
- (action (run ./%{deps} --verbose)))
-
-(executable
+(test
  (name lin_tests_domain)
  (modules lin_tests_domain)
+ (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_common))
+ (libraries lin_tests_common)
+  ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+)
 
-(executables
+(tests
  (names lin_tests_thread_ref lin_tests_thread_conclist)
  (modules lin_tests_thread_ref lin_tests_thread_conclist)
+ (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_common qcheck-lin.thread))
+ (libraries lin_tests_common qcheck-lin.thread)
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name lin_tests_effect)
  (modules lin_tests_effect)
+ (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.effect)
- (preprocess (pps ppx_deriving.show ppx_deriving.eq)))
-
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests_domain.exe)
-;  (action (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_thread_ref.exe)
- (action (run ./%{deps} --verbose)))
-
-(rule
- (alias runtest)
- (package multicoretests)
- (deps lin_tests_thread_conclist.exe)
- (action (run ./%{deps} --verbose)))
-
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests_effect.exe)
-;  (action (run ./%{deps} --verbose)))
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq))
+  ; (action (run ./%{deps} --verbose))
+ (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+)

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -8,27 +8,22 @@
    lin_tests.exe ;; currently not run on CI
    lin_tests_dsl.exe))
 
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (flags (:standard -w -27))
- (libraries qcheck-lin.domain qcheck-lin.thread))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
-
-(executable
- (name lin_tests)
- (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (action (run %{test} --verbose))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+(test
+ (name lin_tests)
+ (modules lin_tests)
+ (package multicoretests)
+ (flags (:standard -w -27))
+ (libraries qcheck-lin.domain qcheck-lin.thread)
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+ ;(action (run %{test} --verbose))
+ (action (echo "Skipping src/queue/%{test} from the test suite\n\n"))
+)

--- a/src/semaphore/dune
+++ b/src/semaphore/dune
@@ -6,14 +6,11 @@
  (package multicoretests)
  (deps stm_tests.exe))
 
-(executable
+(test
  (name stm_tests)
  (modules stm_tests)
- (libraries qcheck-stm.sequential qcheck-stm.domain)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps stm_tests.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries qcheck-stm.sequential qcheck-stm.domain)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -8,28 +8,23 @@
    lin_tests.exe ;; currently not run on CI
    lin_tests_dsl.exe))
 
-(executable
+(test
  (name lin_tests_dsl)
  (modules lin_tests_dsl)
- (flags (:standard -w -27))
- (libraries qcheck-lin.domain qcheck-lin.thread))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps lin_tests_dsl.exe)
- (action (run ./%{deps} --verbose)))
-
-(executable
- (name lin_tests)
- (modules lin_tests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq)))
+ (action (run %{test} --verbose))
+)
 
-; (rule
-;  (alias runtest)
-;  (package multicoretests)
-;  (deps lin_tests.exe)
-;  (action (run ./%{deps} --verbose)))
+(test
+ (name lin_tests)
+ (modules lin_tests)
+ (package multicoretests)
+ (flags (:standard -w -27))
+ (libraries qcheck-lin.domain qcheck-lin.thread)
+ (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
+  ; (action (run %{test} --verbose))
+ (action (echo "Skipping src/stack/%{test} from the test suite\n\n"))
+)
 

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -6,29 +6,22 @@
  (package multicoretests)
  (deps thread_joingraph.exe thread_createtree.exe))
 
-
 ;; Tests of Domain's spawn functionality (non-STM)
 
-(executable
+(test
  (name thread_joingraph)
  (modules thread_joingraph)
- (libraries threads qcheck-core util)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps thread_joingraph.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries threads qcheck-core util)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)
 
-(executable
+(test
  (name thread_createtree)
  (modules thread_createtree)
- (libraries threads qcheck-core util)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
- (deps thread_createtree.exe)
  (package multicoretests)
- (action (run ./%{deps} --verbose)))
+ (libraries threads qcheck-core util)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)

--- a/src/threadomain/dune
+++ b/src/threadomain/dune
@@ -6,14 +6,11 @@
  (package multicoretests)
  (deps threadomain.exe))
 
-(executable
+(test
  (name threadomain)
  (modules threadomain)
- (libraries util qcheck-core threads)
- (preprocess (pps ppx_deriving.show)))
-
-(rule
- (alias runtest)
  (package multicoretests)
- (deps threadomain.exe)
- (action (run ./%{deps} --verbose)))
+ (libraries util qcheck-core threads)
+ (preprocess (pps ppx_deriving.show))
+ (action (run %{test} --verbose))
+)


### PR DESCRIPTION
This PR offers an alternative solution to the missing `(package ...)` annotations and the solution suggested in #249.
Instead it merges `(executable ...)` and `(rule ...)` stanzas into `(test ...)s`
while adding the missing `(package …)` annotations.
This has the advantage of simplifying our dune rules.