### PR TITLE
Pin lockfree to the last version before dscheck dependency

### DIFF
--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -49,5 +49,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"
 pin-depends: [
-  ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]
+  ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#9d5ef7f434b66e09b023a289641edfc2dfd742e8"]
 ]

--- a/multicoretests.opam.template
+++ b/multicoretests.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#main"]
+  ["lockfree.v0.2.0"           "git+https://github.com/ocaml-multicore/lockfree#9d5ef7f434b66e09b023a289641edfc2dfd742e8"]
 ]


### PR DESCRIPTION
Some recursive dependency of dscheck does not build on bytecode-only OCaml so pin lockfree before that change to keep that target.

Hopefully should close #258.