### PR TITLE
Shorten workflow names by dropping (redundant) numbers

### DIFF
--- a/.github/workflows/linux-500-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0+trunk bytecode
+name: Bytecode trunk
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0~rc1 bytecode
+name: Bytecode RC1
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-debug-trunk-workflow.yml
+++ b/.github/workflows/linux-500-debug-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0+trunk debug
+name: Linux trunk debug
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-debug-workflow.yml
+++ b/.github/workflows/linux-500-debug-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0~rc1 debug
+name: Linux RC1 debug
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-trunk-workflow.yml
+++ b/.github/workflows/linux-500-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0+trunk
+name: Linux trunk
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux 5.0.0~rc1
+name: Linux RC1
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/macosx-500-trunk-workflow.yml
+++ b/.github/workflows/macosx-500-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: MacOSX 5.0.0+trunk
+name: macOS trunk
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -1,4 +1,4 @@
-name: MacOSX 5.0.0~rc1
+name: macOS RC1
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/windows-500-trunk-workflow.yml
+++ b/.github/workflows/windows-500-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Windows 5.0.0+trunk
+name: Windows trunk
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/windows-500-workflow.yml
+++ b/.github/workflows/windows-500-workflow.yml
@@ -1,4 +1,4 @@
-name: Windows 5.0.0-rc1
+name: Windows RC1
 
 on: [push, pull_request, workflow_dispatch]
 


### PR DESCRIPTION
First proposition to address #260. Names could be shortened further (Linux, Win, Mac, BC; tr for trunk) if need be.