### PR TITLE
Faster Lin check for pure operations

### DIFF
--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -131,8 +131,9 @@ struct
               check_seq_step c2 res2 cs1 cs2' seq_sut' seq_trace)
           end
 
-    let check_seq_cons pref cs1 cs2 seq_sut seq_trace =
-      match check_seq pref seq_sut seq_trace with
+    let check_seq_cons pref cs1 cs2 =
+      let seq_sut = Spec.init () in
+      match check_seq pref seq_sut [] with
       | None -> false
       | Some seq_trace -> check_seq_cons cs1 cs2 seq_sut seq_trace
 

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -265,8 +265,7 @@ val ( @-> ) :
 (** {1 API description} *)
 
 (** Type and constructor to capture a single function signature *)
-type _ elem = private
-  | Elem : string * ('ftyp, 'r, 's) Fun.fn * 'ftyp -> 's elem
+type !_ elem
 
 type 's api = (int * 's elem) list
 (** The type of module signatures *)

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -24,6 +24,9 @@ module Internal : sig
     (** A command shrinker.
         To a first approximation you can use {!QCheck.Shrink.nil}. *)
 
+    val is_pure : cmd -> bool
+    (** [is_pure c] returns [true] if the command [c] is free of side-effects. *)
+
     type res
     (** The command result type *)
 
@@ -270,11 +273,14 @@ type !_ elem
 type 's api = (int * 's elem) list
 (** The type of module signatures *)
 
-val val_ : string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
+val val_ : ?pure:bool -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
 (** [val_ str f sig] describes a function signature from a string [str],
-    a function value [f], and a signature description [sig]. *)
+    a function value [f], and a signature description [sig].
 
-val val_freq : int -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
+    - The optional argument [?pure] is [false] by default. If [true] then the
+      function must be free of side-effects. *)
+
+val val_freq : ?pure:bool -> int -> string -> 'f -> ('f, 'r, 's) Fun.fn -> int * 's elem
 (** [val_freq w str f sig] describes a function signature like
     {!val_} [str f sig] but with relative weight [w] rather than 1.
     A function of weight 2 will have twice the probability of being

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -49,7 +49,7 @@ module Internal : sig
 
   module Make(Spec : CmdSpec) : sig
     val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
-    val check_seq_cons : (Spec.cmd * Spec.res) list -> (Spec.cmd * Spec.res) list -> (Spec.cmd * Spec.res) list -> Spec.t -> Spec.cmd list -> bool
+    val check_seq_cons : (Spec.cmd * Spec.res) list -> (Spec.cmd * Spec.res) list -> (Spec.cmd * Spec.res) list -> bool
     val interp_plain : Spec.t -> Spec.cmd list -> (Spec.cmd * Spec.res) list
     val lin_test : rep_count:int -> retries:int -> count:int -> name:string -> lin_prop:(Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool) -> QCheck.Test.t
     val neg_lin_test : rep_count:int -> retries:int -> count:int -> name:string -> lin_prop:(Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool) -> QCheck.Test.t

--- a/lib/lin_domain.ml
+++ b/lib/lin_domain.ml
@@ -21,8 +21,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
     let obs2 = Domain.join dom2 in
     let obs1 = match obs1 with Ok v -> v | Error exn -> raise exn in
     let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
-    let seq_sut = Spec.init () in
-    check_seq_cons pref_obs obs1 obs2 seq_sut []
+    check_seq_cons pref_obs obs1 obs2
       || QCheck.Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
          @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))

--- a/lib/lin_effect.ml
+++ b/lib/lin_effect.ml
@@ -107,9 +107,8 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
          fork (fun () -> let tmp2 = interp sut cmds2 in obs2 := tmp2); in
        let () = start_sched main in
        let () = Spec.cleanup sut in
-       let seq_sut = Spec.init () in
        (* exclude [Yield]s from sequential executions when searching for an interleaving *)
-       EffTest.check_seq_cons (filter_res pref_obs) (filter_res !obs1) (filter_res !obs2) seq_sut []
+       EffTest.check_seq_cons (filter_res pref_obs) (filter_res !obs1) (filter_res !obs2)
        || QCheck.Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
        @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
          (fun (c,r) -> Printf.sprintf "%s : %s" (EffSpec.show_cmd c) (EffSpec.show_res r))

--- a/lib/lin_effect.ml
+++ b/lib/lin_effect.ml
@@ -60,6 +60,10 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
       | SchedYield -> Iter.empty
       | UserCmd c -> Iter.map (fun c' -> UserCmd c') (Spec.shrink_cmd c)
 
+    let is_pure = function
+      | UserCmd c -> Spec.is_pure c
+      | SchedYield -> false
+
     type res = SchedYieldRes | UserRes of Spec.res
 
     let show_res r = match r with

--- a/lib/lin_thread.ml
+++ b/lib/lin_thread.ml
@@ -29,9 +29,8 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
       Thread.join th1;
       Thread.join th2;
       Spec.cleanup sut;
-      let seq_sut = Spec.init () in
       (* we reuse [check_seq_cons] to linearize and interpret sequentially *)
-      check_seq_cons pref_obs !obs1 !obs2 seq_sut []
+      check_seq_cons pref_obs !obs1 !obs2
       || QCheck.Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
          @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -23,6 +23,10 @@ struct
 
   let shrink_cmd c = Iter.empty
 
+  let is_pure = function
+    | Length | Get _ | Sub _ | Copy | To_list | Mem _ | To_seq -> true
+    | Set _ | Fill _ | Sort -> false
+
   open Util
   (*let pp_exn = Util.pp_exn*)
   type res =

--- a/src/array/lin_tests_dsl.ml
+++ b/src/array/lin_tests_dsl.ml
@@ -13,16 +13,16 @@ struct
   let int,char = nat_small,char_printable
   let array_to_seq a = List.to_seq (List.of_seq (Array.to_seq a)) (* workaround: Array.to_seq is lazy and will otherwise see and report later Array.set state changes... *)
   let api =
-    [ val_ "Array.length"   Array.length   (t @-> returning int);
-      val_ "Array.get"      Array.get      (t @-> int @-> returning_or_exc char);
+    [ val_ "Array.length"   Array.length   (t @-> returning int) ~pure:true;
+      val_ "Array.get"      Array.get      (t @-> int @-> returning_or_exc char) ~pure:true;
       val_ "Array.set"      Array.set      (t @-> int @-> char @-> returning_or_exc unit);
-      val_ "Array.sub"      Array.sub      (t @-> int @-> int @-> returning_or_exc (array char));
-      val_ "Array.copy"     Array.copy     (t @-> returning (array char));
+      val_ "Array.sub"      Array.sub      (t @-> int @-> int @-> returning_or_exc (array char)) ~pure:true;
+      val_ "Array.copy"     Array.copy     (t @-> returning (array char)) ~pure:true;
       val_ "Array.fill"     Array.fill     (t @-> int @-> int @-> char @-> returning_or_exc unit);
-      val_ "Array.to_list"  Array.to_list  (t @-> returning (list char));
-      val_ "Array.mem"      Array.mem      (char @-> t @-> returning bool);
+      val_ "Array.to_list"  Array.to_list  (t @-> returning (list char)) ~pure:true;
+      val_ "Array.mem"      Array.mem      (char @-> t @-> returning bool) ~pure:true;
       val_ "Array.sort"     (Array.sort Char.compare) (t @-> returning unit);
-      val_ "Array.to_seq"   array_to_seq   (t @-> returning (seq char));
+      val_ "Array.to_seq"   array_to_seq   (t @-> returning (seq char)) ~pure:true;
     ]
 end
 

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -19,6 +19,10 @@ struct
 
   let shrink_cmd = Shrink.nil
 
+  let is_pure = function
+    | Get -> true
+    | Set _ | Exchange _ | Compare_and_set _ | Fetch_and_add _ | Incr | Decr -> false
+
   type res =
     | RGet of int
     | RSet
@@ -61,6 +65,10 @@ struct
   and var  = int [@gen Gen.int_bound 2]
 
   let shrink_cmd = Shrink.nil
+
+  let is_pure = function
+    | Get _ -> true
+    | Set _ | Exchange _ | Compare_and_set _ | Fetch_and_add _ | Incr _ | Decr _ -> false
 
   type res =
     | RGet of int

--- a/src/atomic/lin_tests_dsl.ml
+++ b/src/atomic/lin_tests_dsl.ml
@@ -4,7 +4,7 @@ module Atomic_spec : Lin.Spec = struct
   let init () = Atomic.make 0
   let cleanup _ = ()
   let api =
-    [ val_ "Atomic.get"             Atomic.get             (t @-> returning int);
+    [ val_ "Atomic.get"             Atomic.get             (t @-> returning int) ~pure:true;
       val_ "Atomic.set"             Atomic.set             (t @-> int @-> returning unit);
       val_ "Atomic.exchange"        Atomic.exchange        (t @-> int @-> returning int);
       val_ "Atomic.fetch_and_add"   Atomic.fetch_and_add   (t @-> int @-> returning int);

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -9,12 +9,12 @@ module BConf = struct
   open Lin
 
   let api = [
-    val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
-    val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
-    val_ "Bytes.length"      Bytes.length      (t @-> returning int);
+    val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char) ~pure:true;
+    val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string) ~pure:true;
+    val_ "Bytes.length"      Bytes.length      (t @-> returning int) ~pure:true;
     val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
-    val_ "Bytes.index_from"  Bytes.index_from  (t @-> int @-> char @-> returning_or_exc int)]
+    val_ "Bytes.index_from"  Bytes.index_from  (t @-> int @-> char @-> returning_or_exc int) ~pure:true]
 end
 
 module BT_domain = Lin_domain.Make(BConf)

--- a/src/ephemeron/lin_tests_dsl.ml
+++ b/src/ephemeron/lin_tests_dsl.ml
@@ -28,12 +28,12 @@ module EConf =
       [ val_ "Ephemeron.clear"    E.clear    (t @-> returning unit);
         val_ "Ephemeron.add"      E.add      (t @-> int @-> string @-> returning unit);
         val_ "Ephemeron.remove"   E.remove   (t @-> int @-> returning unit);
-        val_ "Ephemeron.find"     E.find     (t @-> int @-> returning_or_exc string);
-        val_ "Ephemeron.find_opt" E.find_opt (t @-> int @-> returning (option string));
-        val_ "Ephemeron.find_all" E.find_all (t @-> int @-> returning (list string));
+        val_ "Ephemeron.find"     E.find     (t @-> int @-> returning_or_exc string) ~pure:true;
+        val_ "Ephemeron.find_opt" E.find_opt (t @-> int @-> returning (option string)) ~pure:true;
+        val_ "Ephemeron.find_all" E.find_all (t @-> int @-> returning (list string)) ~pure:true;
         val_ "Ephemeron.replace"  E.replace  (t @-> int @-> string @-> returning unit);
-        val_ "Ephemeron.mem"      E.mem      (t @-> int @-> returning bool);
-        val_ "Ephemeron.length"   E.length   (t @-> returning int);
+        val_ "Ephemeron.mem"      E.mem      (t @-> int @-> returning bool) ~pure:true;
+        val_ "Ephemeron.length"   E.length   (t @-> returning int) ~pure:true;
         val_ "Ephemeron.clean"    E.clean    (t @-> returning unit);
       ]
   end

--- a/src/floatarray/lin_tests_dsl.ml
+++ b/src/floatarray/lin_tests_dsl.ml
@@ -18,18 +18,18 @@ struct
   let strict_to_seq a = List.to_seq (List.of_seq (Float.Array.to_seq a))
 
   let api =
-    [ val_ "Float.Array.length"      Float.Array.length                      (t@-> returning int);
-      val_ "Float.Array.get"         Float.Array.get                         (t@-> int @-> returning_or_exc float);
+    [ val_ "Float.Array.length"      Float.Array.length                      (t@-> returning int) ~pure:true;
+      val_ "Float.Array.get"         Float.Array.get                         (t@-> int @-> returning_or_exc float) ~pure:true;
       val_ "Float.Array.set"         Float.Array.set                         (t@-> int @-> float @-> returning_or_exc unit);
       val_ "Float.Array.fill"        Float.Array.fill                        (t@-> int @-> int @-> float @-> returning_or_exc unit);
-      val_ "Float.Array.to_list"     Float.Array.to_list                     (t@-> returning (list float));
-      val_ "Float.Array.mem"         Float.Array.mem                         (float @-> t @-> returning bool);
-      val_ "Float.Array.mem_ieee"    Float.Array.mem_ieee                    (float @-> t @-> returning bool);
+      val_ "Float.Array.to_list"     Float.Array.to_list                     (t@-> returning (list float)) ~pure:true;
+      val_ "Float.Array.mem"         Float.Array.mem                         (float @-> t @-> returning bool) ~pure:true;
+      val_ "Float.Array.mem_ieee"    Float.Array.mem_ieee                    (float @-> t @-> returning bool) ~pure:true;
       val_ "Float.Array.sort"        (Float.Array.sort compare)              (t@-> returning unit);
       val_ "Float.Array.stable_sort" (Float.Array.stable_sort compare)       (t@-> returning unit);
       val_ "Float.Array.fast_sort"   (Float.Array.fast_sort compare)         (t@-> returning unit);
-      val_ "Float.Array.to_seq"      strict_to_seq                           (t@-> returning (seq float));
-      val_ "Float.Array.to_array"    (Float.Array.map_to_array (fun x -> x)) (t@-> returning (array float));
+      val_ "Float.Array.to_seq"      strict_to_seq                           (t@-> returning (seq float)) ~pure:true;
+      val_ "Float.Array.to_array"    (Float.Array.map_to_array (fun x -> x)) (t@-> returning (array float)) ~pure:true;
     ]
 end
 

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -38,6 +38,10 @@ struct
     | Mem c -> Iter.map (fun c -> Mem c) (Shrink.char c)
     | Length -> Iter.empty
 
+  let is_pure = function
+    | Find _ | Find_opt _ | Find_all _ | Mem _ | Length -> true
+    | Clear | Add _ | Remove _ | Replace _ -> false
+
   type res =
     | RClear
     | RAdd

--- a/src/hashtbl/lin_tests_dsl.ml
+++ b/src/hashtbl/lin_tests_dsl.ml
@@ -14,12 +14,12 @@ struct
     [ val_ "Hashtbl.clear"    Hashtbl.clear    (t @-> returning unit);
       val_ "Hashtbl.add"      Hashtbl.add      (t @-> char @-> int @-> returning unit);
       val_ "Hashtbl.remove"   Hashtbl.remove   (t @-> char @-> returning unit);
-      val_ "Hashtbl.find"     Hashtbl.find     (t @-> char @-> returning_or_exc int);
-      val_ "Hashtbl.find_opt" Hashtbl.find_opt (t @-> char @-> returning (option int));
-      val_ "Hashtbl.find_all" Hashtbl.find_all (t @-> char @-> returning (list int));
+      val_ "Hashtbl.find"     Hashtbl.find     (t @-> char @-> returning_or_exc int) ~pure:true;
+      val_ "Hashtbl.find_opt" Hashtbl.find_opt (t @-> char @-> returning (option int)) ~pure:true;
+      val_ "Hashtbl.find_all" Hashtbl.find_all (t @-> char @-> returning (list int)) ~pure:true;
       val_ "Hashtbl.replace"  Hashtbl.replace  (t @-> char @-> int @-> returning unit);
-      val_ "Hashtbl.mem"      Hashtbl.mem      (t @-> char @-> returning bool);
-      val_ "Hashtbl.length"   Hashtbl.length   (t @-> returning int);
+      val_ "Hashtbl.mem"      Hashtbl.mem      (t @-> char @-> returning bool) ~pure:true;
+      val_ "Hashtbl.length"   Hashtbl.length   (t @-> returning int) ~pure:true;
     ]
 end
 

--- a/src/internal/cleanup.ml
+++ b/src/internal/cleanup.ml
@@ -24,6 +24,10 @@ struct
 
   let shrink_cmd = Shrink.nil
 
+  let is_pure = function
+    | Get -> true
+    | Set _ | Add _ -> false
+
   let init () = (ref Inited, ref 0)
 
   let cleanup (status,_) =

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -52,6 +52,10 @@ struct
   (* the Lazy tests already take a while to run - so better avoid spending extra time shrinking *)
   let shrink_cmd = Shrink.nil
 
+  let is_pure = function
+    | Is_val -> true
+    | Force | Force_val | Map _ | Map_val _ -> false
+
   type t = int Lazy.t
 
   let cleanup _ = ()

--- a/src/lazy/lin_tests_dsl.ml
+++ b/src/lazy/lin_tests_dsl.ml
@@ -48,7 +48,7 @@ struct
   let api =
     [ val_ "Lazy.force"                Lazy.force     (t @-> returning_or_exc int);
       val_ "Lazy.force_val"            Lazy.force_val (t @-> returning_or_exc int);
-      val_ "Lazy.is_val"               Lazy.is_val    (t @-> returning bool);
+      val_ "Lazy.is_val"               Lazy.is_val    (t @-> returning bool) ~pure:true;
     (*val_ "Lazy.map"                  Lazy.map       (fun_gen int int @-> t @-> returning_or_exc t);*)
       val_ "Lazy.force o Lazy.map"     force_map      (fun_gen int int @-> t @-> returning_or_exc int);
     (*val_ "Lazy.map_val"              Lazy.map       (fun_gen int int @-> t @-> returning_or_exc t);*)

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -41,6 +41,10 @@ module RConf_int = struct
     | Set i -> Iter.map (fun i -> Set i) (Shrink.int i)
     | Add i -> Iter.map (fun i -> Add i) (Shrink.int i)
 
+  let is_pure = function
+    | Get -> true
+    | Set _ | Add _ | Incr | Decr -> false
+
   type res = RGet of int | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }, eq]
 
   let init () = Sut_int.init ()
@@ -73,6 +77,10 @@ module RConf_int64 = struct
     | Decr -> Iter.empty
     | Set i -> Iter.map (fun i -> Set i) (Shrink.int64 i)
     | Add i -> Iter.map (fun i -> Add i) (Shrink.int64 i)
+
+  let is_pure = function
+    | Get -> true
+    | Set _ | Add _ | Incr | Decr -> false
 
   type res = RGet of int64 | RSet | RAdd | RIncr | RDecr [@@deriving show { with_path = false }, eq]
 
@@ -117,6 +125,10 @@ struct
   let shrink_cmd c = match c with
     | Add_node i -> Iter.map (fun i -> Add_node i) (T.shrink i)
     | Member i -> Iter.map (fun i -> Member i) (T.shrink i)
+
+  let is_pure = function
+    | Member _ -> true
+    | Add_node _ -> false
 
   type res = RAdd_node of bool | RMember of bool [@@deriving show { with_path = false }, eq]
 

--- a/src/neg_tests/lin_tests_dsl_common.ml
+++ b/src/neg_tests/lin_tests_dsl_common.ml
@@ -30,7 +30,7 @@ module Ref_int_spec : Spec = struct
   let cleanup _ = ()
   let int = nat_small
   let api =
-    [ val_ "Sut_int.get"  Sut_int.get  (t @-> returning int);
+    [ val_ "Sut_int.get"  Sut_int.get  (t @-> returning int) ~pure:true;
       val_ "Sut_int.set"  Sut_int.set  (t @-> int @-> returning unit);
       val_ "Sut_int.add"  Sut_int.add  (t @-> int @-> returning unit);
       val_ "Sut_int.incr" Sut_int.incr (t @-> returning unit);
@@ -44,7 +44,7 @@ module Ref_int64_spec : Spec = struct
   let cleanup _ = ()
   let int64 = nat64_small
   let api =
-    [ val_ "Sut_int64.get"  Sut_int64.get  (t @-> returning int64);
+    [ val_ "Sut_int64.get"  Sut_int64.get  (t @-> returning int64) ~pure:true;
       val_ "Sut_int64.set"  Sut_int64.set  (t @-> int64 @-> returning unit);
       val_ "Sut_int64.add"  Sut_int64.add  (t @-> int64 @-> returning unit);
       val_ "Sut_int64.incr" Sut_int64.incr (t @-> returning unit);
@@ -67,7 +67,7 @@ struct
   let int = nat_small
   let api =
     [ val_ "CList.add_node" CList.add_node (t @-> int @-> returning bool);
-      val_ "CList.member"   CList.member  (t @-> int @-> returning bool);
+      val_ "CList.member"   CList.member  (t @-> int @-> returning bool) ~pure:true;
     ]
   end
 
@@ -79,7 +79,7 @@ struct
   let int64 = nat64_small
   let api =
     [ val_ "CList.add_node" CList.add_node (t @-> int64 @-> returning bool);
-      val_ "CList.member"   CList.member  (t @-> int64 @-> returning bool);
+      val_ "CList.member"   CList.member  (t @-> int64 @-> returning bool) ~pure:true;
     ]
   end
 

--- a/src/neg_tests/lin_tests_dsl_effect.ml
+++ b/src/neg_tests/lin_tests_dsl_effect.ml
@@ -18,7 +18,7 @@ module Ref_int'_spec : Spec = struct
   let init () = Sut_int'.init ()
   let cleanup _ = ()
   let api =
-    [ val_ "Sut_int'.get"  Sut_int'.get  (t @-> returning int);
+    [ val_ "Sut_int'.get"  Sut_int'.get  (t @-> returning int) ~pure:true;
       val_ "Sut_int'.set"  Sut_int'.set  (t @-> int @-> returning unit);
       val_ "Sut_int'.add"  Sut_int'.add  (t @-> int @-> returning_or_exc unit);
       val_ "Sut_int'.incr" Sut_int'.incr (t @-> returning unit);
@@ -39,7 +39,7 @@ module Ref_int64'_spec : Spec = struct
   let init () = Sut_int64'.init ()
   let cleanup _ = ()
   let api =
-    [ val_ "Sut_int64'.get"  Sut_int64'.get  (t @-> returning int64);
+    [ val_ "Sut_int64'.get"  Sut_int64'.get  (t @-> returning int64) ~pure:true;
       val_ "Sut_int64'.set"  Sut_int64'.set  (t @-> int64 @-> returning unit);
       val_ "Sut_int64'.add"  Sut_int64'.add  (t @-> int64 @-> returning_or_exc unit);
       val_ "Sut_int64'.incr" Sut_int64'.incr (t @-> returning unit);
@@ -59,7 +59,7 @@ struct
   let add_node r i = Lin_effect.yield (); CList.add_node r i
   let api =
     [ val_ "CList.add_node" add_node (t @-> int @-> returning_or_exc bool);
-      val_ "CList.member"   CList.member  (t @-> int @-> returning bool);
+      val_ "CList.member"   CList.member  (t @-> int @-> returning bool) ~pure:true;
     ]
   end
 module CList_spec_int64' : Spec =
@@ -70,7 +70,7 @@ struct
   let cleanup _ = ()
   let api =
     [ val_ "CList.add_node" add_node (t @-> int64 @-> returning_or_exc bool);
-      val_ "CList.member"   CList.member  (t @-> int64 @-> returning bool);
+      val_ "CList.member"   CList.member  (t @-> int64 @-> returning bool) ~pure:true;
     ]
   end
 

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -34,6 +34,10 @@ module Spec =
             <+>
             (map (fun i -> Fold (f,i)) (Shrink.int i)))
 
+    let is_pure = function
+      | Peek | Peek_opt | Is_empty | Length | Fold _ -> true
+      | Add _ | Take | Take_opt | Clear -> false
+
     type res =
       | RAdd
       | RTake of ((int, exn) result [@equal (=)])

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -8,11 +8,11 @@ module Queue_spec : Lin.Spec = struct
       [ val_ "Queue.add"      Queue.add      (int @-> t @-> returning unit);
         val_ "Queue.take"     Queue.take     (t @-> returning_or_exc int);
         val_ "Queue.take_opt" Queue.take_opt (t @-> returning (option int));
-        val_ "Queue.peek"     Queue.peek     (t @-> returning_or_exc int);
-        val_ "Queue.peek_opt" Queue.peek_opt (t @-> returning (option int));
+        val_ "Queue.peek"     Queue.peek     (t @-> returning_or_exc int) ~pure:true;
+        val_ "Queue.peek_opt" Queue.peek_opt (t @-> returning (option int)) ~pure:true;
         val_ "Queue.clear"    Queue.clear    (t @-> returning unit);
-        val_ "Queue.is_empty" Queue.is_empty (t @-> returning bool);
-        val_ "Queue.length"   Queue.length   (t @-> returning int);
+        val_ "Queue.is_empty" Queue.is_empty (t @-> returning bool) ~pure:true;
+        val_ "Queue.length"   Queue.length   (t @-> returning int) ~pure:true;
         (* val_ "Queue.fold" Queue.fold ... need function type combinator *)
       ]
 end

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -34,6 +34,10 @@ module Spec =
             <+>
             (map (fun i -> Fold (f,i)) (Shrink.int i)))
 
+    let is_pure = function
+      | Is_empty | Length | Fold _ -> true
+      | Push _ | Pop | Pop_opt | Top | Top_opt | Clear -> false
+
     type res =
       | RPush
       | RPop of ((int, exn) result [@equal (=)])


### PR DESCRIPTION
This is just a suggestion, feel free to discard! (... especially since it changes the public API)

I think the sequential consistency check can be a tiny bit faster if the user specifies which operations are side-effect free (because then it doesn't need to replay everything when these functions fail to produce the expected result) ... But then there's a risk that a user could misuse the `pure` annotation!

Some very arbitrary benchmarks (I didn't find an existing test that performs worse with the `~pure:true` annotations, most are already very fast):

- Queue before/after:

  ```
  src/queue $ dune exec -- ./lin_tests.exe --seed 0 -v
  
  generated error fail pass / total     time test name
  [✓] 1000    0    0 1000 / 1000     4.1s Lin Queue test with Domain and mutex
  [✓] 1000    0    0 1000 / 1000     8.0s Lin Queue test with Thread and mutex
  [✓]    1    0    1    0 / 1000     2.1s Lin Queue test with Domain without mutex
  [✓] 1000    0    0 1000 / 1000     6.9s Lin Queue test with Thread without mutex
  
  [✓] 1000    0    0 1000 / 1000     3.6s Lin Queue test with Domain and mutex
  [✓] 1000    0    0 1000 / 1000     6.0s Lin Queue test with Thread and mutex
  [✓]    1    0    1    0 / 1000     2.1s Lin Queue test with Domain without mutex
  [✓] 1000    0    0 1000 / 1000     5.9s Lin Queue test with Thread without mutex
  ```

- I didn't expect Lazy to benefit as much, since only `is_val` is pure:

  ```
  src/lazy $ dune exec -- ./lin_tests_dsl.exe --seed 0 -v
  
  generated error fail pass / total     time test name
  [✓]   39    0    1   38 /  100   157.7s Lin DSL Lazy test with Domain
  [✓]  100    0    0  100 /  100     0.3s Lin DSL Lazy test with Domain from_val
  [✓]   39    0    1   38 /  100   136.6s Lin DSL Lazy test with Domain from_fun
  
  [✓]   39    0    1   38 /  100    95.6s Lin DSL Lazy test with Domain
  [✓]  100    0    0  100 /  100     0.3s Lin DSL Lazy test with Domain from_val
  [✓]   39    0    1   38 /  100    96.1s Lin DSL Lazy test with Domain from_fun
  ```

(The tests produce the same counter-examples as before)