### PR TITLE
Increase the timeout for the debug-runtime tests

### DIFF
--- a/.github/workflows/linux-500-debug-trunk-workflow.yml
+++ b/.github/workflows/linux-500-debug-trunk-workflow.yml
@@ -10,3 +10,4 @@ jobs:
       compiler_branch: '5.0'
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
+      timeout: 360

--- a/.github/workflows/linux-500-debug-workflow.yml
+++ b/.github/workflows/linux-500-debug-workflow.yml
@@ -8,3 +8,4 @@ jobs:
     with:
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
+      timeout: 360


### PR DESCRIPTION
The debug runtime is slower than the standard runtime, so that it regularly runs out of time during CI, so give it the same timeout as other slow platforms (bytecode and windows)