### PR TITLE
Switch CI from rc1 to 5.0.0 release

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -14,7 +14,7 @@ on:
       compiler:
         description: 'Compiler to use'
         type: string
-        default: 'ocaml-base-compiler.5.0.0~rc1'
+        default: 'ocaml-base-compiler.5.0.0'
       compiler_branch:
         description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
         type: string

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,11 +17,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.opam
-          key: opam-ubuntu-latest-5.0.0~rc1
+          key: opam-ubuntu-latest-5.0.0
 
       - uses: avsm/setup-ocaml@v2
         with:
-          ocaml-compiler: 'ocaml-base-compiler.5.0.0~rc1'
+          ocaml-compiler: 'ocaml-base-compiler.5.0.0'
           default: https://github.com/ocaml/opam-repository.git
           alpha: https://github.com/kit-ty-kate/opam-alpha-repository.git
 

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -1,4 +1,4 @@
-name: Bytecode RC1
+name: Bytecode 5.0.0
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-bytecode-workflow.yml
+++ b/.github/workflows/linux-500-bytecode-workflow.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.0.0~rc1+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.0.0+options,ocaml-option-bytecode-only'
       timeout: 360

--- a/.github/workflows/linux-500-debug-workflow.yml
+++ b/.github/workflows/linux-500-debug-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux RC1 debug
+name: Linux 5.0.0
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/linux-500-workflow.yml
+++ b/.github/workflows/linux-500-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux RC1
+name: Linux 5.0.0
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/macosx-500-workflow.yml
+++ b/.github/workflows/macosx-500-workflow.yml
@@ -1,4 +1,4 @@
-name: macOS RC1
+name: macOS 5.0.0
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/windows-500-workflow.yml
+++ b/.github/workflows/windows-500-workflow.yml
@@ -1,4 +1,4 @@
-name: Windows RC1
+name: Windows 5.0.0
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ on:
       compiler:
         description: 'Branch or tag of ocaml/ocaml to use as compiler'
         type: string
-        default: '5.0.0-rc1'
+        default: '5.0.0'
       only_test:
         description: 'Only test to run (eg “src/array/lin_tests.exe”); whole suite is run if empty'
         type: string


### PR DESCRIPTION
This PR switched the CI from 5.0.0~rc1 to the 5.0.0 release.
It doesn't touch the (currently broken) 5.0.0+trunk workflows.