### PR TITLE
Add latest issues and regenerate opam files

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ property can be done in two different ways:
 Issues
 ======
 
+`Sys.readdir` on MingW Windows disagrees with Linux behavior (new)
+------------------------------------------------------------------
+
+Sequential `STM` tests of `Sys` showed how `Sys.readdir` of a
+non-existing directory on MingW Windows [returns an empty `array`, thus
+disagreeing with the Linux and macOS behavior](https://github.com/ocaml/ocaml/issues/11829)
+
+
+`seek` on a closed `in_channel` may read uninitialized memory (new)
+-------------------------------------------------------------------
+
+A failure of `Lin` `In_channel` tests revealed that `seek` on a closed
+`in_channel` [may read uninitialized memory](https://github.com/ocaml/ocaml/issues/11878)
+
+
 Parallel usage of `Weak` could produce weird values (new, fixed)
 ----------------------------------------------------------------
 

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -20,7 +20,7 @@ tags: [
 homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "base-domains"
   "ppx_deriving" {>= "5.2.1"}
   "qcheck-core" {>= "0.20"}
@@ -38,11 +38,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"

--- a/qcheck-lin.opam
+++ b/qcheck-lin.opam
@@ -21,7 +21,7 @@ tags: [
 homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "base-domains"
   "qcheck-core" {>= "0.20"}
   "qcheck-multicoretests-util" {= version}
@@ -36,11 +36,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"

--- a/qcheck-multicoretests-util.opam
+++ b/qcheck-multicoretests-util.opam
@@ -13,7 +13,7 @@ tags: ["test" "property" "qcheck" "quickcheck" "multicore" "non-determinism"]
 homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "base-domains"
   "qcheck-core" {>= "0.20"}
   "odoc" {with-doc}
@@ -27,11 +27,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"

--- a/qcheck-stm.opam
+++ b/qcheck-stm.opam
@@ -21,7 +21,7 @@ tags: [
 homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.0"}
   "base-domains"
   "qcheck-core" {>= "0.20"}
   "qcheck-multicoretests-util" {= version}
@@ -36,11 +36,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/ocaml-multicore/multicoretests.git"


### PR DESCRIPTION
This little PR
- adds the latest two issues found by @Lucccyo and @shym 
- regenerates the included `opam` files - as the bump to dune 3.0 in #255 apparently causes changes in the output :shrug: 