### PR TITLE
Reduce STM_domain retries

### DIFF
--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -39,7 +39,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make ~retries:15 ~max_gen ~count ~name
+    Test.make ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
 
@@ -47,7 +47,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make_neg ~retries:15 ~max_gen ~count ~name
+    Test.make_neg ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
   end


### PR DESCRIPTION
While commenting on #129 I realized the `STM_domain` `retries` count is relatively high at `15`.
When combined with a `rep_count:25` for `Util.repeat` it means we end up repeating a property 15*25=375 times during shrinking for each shrinking candidate that fails!
In comparison Lin_domain uses `retries:3` and `rep_count:50` meaning it repeats a property 150 times during shrinking.

This PR therefore reduces `retries` to `10`, thus lowering shrink repetitions to `250` to avoid burning needless CPU cycles.
I have checked locally that all existing negative `STM` tests still fail with a nice and short counterexample.

For, e.g., the bytecode CI target I'm expecting/hoping this will reduce the runtime a bit.