### PR TITLE
Add a (negative) Lin test for Dynlink module

### DIFF
--- a/src/dynlink/dune
+++ b/src/dynlink/dune
@@ -1,0 +1,19 @@
+;; Test of the Dynlink module of the standard library
+
+(library
+ (name libA)
+ (modules libA)
+)
+
+(library
+ (name libB)
+ (modules libB)
+)
+
+(test
+ (name lin_tests_dsl)
+ (modules lin_tests_dsl)
+ (package multicoretests)
+ (libraries qcheck-lin.domain dynlink libA libB)
+ (action (run %{test} --verbose))
+)

--- a/src/dynlink/libA.ml
+++ b/src/dynlink/libA.ml
@@ -1,0 +1,1 @@
+let value = 12

--- a/src/dynlink/libB.ml
+++ b/src/dynlink/libB.ml
@@ -1,0 +1,1 @@
+let value = 34

--- a/src/dynlink/lin_tests_dsl.ml
+++ b/src/dynlink/lin_tests_dsl.ml
@@ -1,0 +1,36 @@
+(* ************************************ *)
+(*           Tests of Dynlink           *)
+(* ************************************ *)
+
+open Lin
+
+(* Two libraries that should exist, one that should not *)
+let library_name = QCheck.Gen.oneofl ["libA.cma"; "libB.cma"; "libC.cma"]
+let arb_library = QCheck.make library_name
+let print_library l = QCheck.Print.string (Dynlink.adapt_filename l)
+
+(** A {!Lin} {i type} for files that can be dynamically linked *)
+let library = gen_deconstructible arb_library print_library (=)
+
+let loadfile f = Dynlink.loadfile (Dynlink.adapt_filename f)
+
+module DynConf =
+struct
+  type t = unit
+
+  let init () = ()
+  let cleanup _ = ()
+
+  let api =
+    [ val_ "Dynlink.loadfile"           loadfile                   (library @-> returning_or_exc unit);
+      val_ "Dynlink.main_program_units" Dynlink.main_program_units (unit @-> returning (list string));
+      val_ "Dynlink.all_units"          Dynlink.all_units          (unit @-> returning (list string));
+    ]
+end
+
+module DynT = Lin_domain.Make(DynConf)
+
+let _ =
+  QCheck_base_runner.run_tests_main [
+    DynT.neg_lin_test ~count:100 ~name:"negative Lin DSL Dynlink test with Domain";
+  ]


### PR DESCRIPTION
This adds a (preliminary) Lin test for the `Dynlink` module, only testing three functions at the moment.
Its first run triggered a segfault on Windows in CI.