### PR TITLE
Rewrite the CI workflows to run the test suite on a specific compiler (specific commit or branch)

### DIFF
--- a/.github/opam/custom/repo
+++ b/.github/opam/custom/repo
@@ -1,0 +1,1 @@
+opam-version: "2.0"

--- a/.github/opam/ocaml-variants.opam.unix
+++ b/.github/opam/ocaml-variants.opam.unix
@@ -1,0 +1,108 @@
+opam-version: "2.0"
+name: "ocaml-variants"
+synopsis: "Custom compiler __OCAML_COMPILER_FULL_VERSION__"
+maintainer: "platform@lists.ocaml.org"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {= "__OCAML_OPAM_PACKAGE_VERSION__" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  "ocaml-beta" {opam-version < "2.1.0"}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+]
+conflict-class: "ocaml-core-compiler"
+flags: [compiler avoid-version]
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "CC=cc"
+      {!ocaml-option-32bit:installed & !ocaml-option-musl:installed &
+       (os = "openbsd" | os = "macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution != "alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "LDFLAGS=-Wl,--no-as-needed,-ldl"
+      {ocaml-option-leak-sanitizer:installed |
+       ocaml-option-address-sanitizer:installed & os != "macos"}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g"
+      {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g"
+      {ocaml-option-address-sanitizer:installed & os != "macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g"
+      {ocaml-option-address-sanitizer:installed & os = "macos"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os = "linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "ASPP=cc -c"
+      {!ocaml-option-32bit:installed & !ocaml-option-musl:installed &
+       (os = "openbsd" | os = "macos")}
+    "ASPP=musl-gcc -c"
+      {ocaml-option-musl:installed & os-distribution != "alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os = "linux"}
+    "ASPP=gcc -arch i386 -m32 -c"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os = "linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os = "macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os = "linux"}
+    "--host=i386-apple-darwin13.2.0"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "PARTIALLD=ld -r -melf_i386"
+      {ocaml-option-32bit:installed & os = "linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+build-env: [
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+post-messages: [
+  """\
+A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   See https://github.com/ocaml/opam-repository/pull/14257 for more info."""
+    {failure & jobs > "1" & os != "cygwin"}
+  """\
+You can try installing again including --jobs=1
+   to force a sequential build instead."""
+    {failure & jobs > "1" & os != "cygwin" & opam-version >= "2.0.5"}
+]
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+url {
+  src: "__OCAML_COMPILER_SRC__"
+}

--- a/.github/opam/ocaml-variants.opam.windows
+++ b/.github/opam/ocaml-variants.opam.windows
@@ -1,0 +1,119 @@
+opam-version: "2.0"
+name: "ocaml-variants"
+synopsis: "Custom compiler __OCAML_COMPILER_FULL_VERSION__"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+maintainer: "platform@lists.ocaml.org"
+authors: ["Xavier Leroy" "Damien Doligez" "Alain Frisch" "Jacques Garrigue" "Didier Rémy" "Jérôme Vouillon"]
+homepage: "https://ocaml.org"
+bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
+dev-repo: "git+https://github.com/ocaml/ocaml.git"
+depends: [
+  "ocaml" {= "__OCAML_OPAM_PACKAGE_VERSION__" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-domains" {post}
+  "base-nnp" {post}
+  "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
+  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {post})
+]
+conflict-class: "ocaml-core-compiler"
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build-env: [
+  [PATH += "%{lib}%/%{flexdll-bin:installed?flexdll-bin:ocaml}%"]
+  [LSAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+  [ASAN_OPTIONS = "detect_leaks=0,exitcode=0"]
+]
+build: [
+  [
+    # General configuration
+    "./configure" "-C" "--prefix=%{prefix}%" "--docdir=%{doc}%/ocaml"
+
+    # Windows-specific configuration
+    "--with-flexdll=%{flexdll:share}%" {flexdll:installed}
+
+    # Options
+    "--disable-warn-error"
+
+    "--enable-native-compiler" {!ocaml-option-bytecode-only:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+
+    "LIBS=-static" {ocaml-option-static:installed}
+
+    # Force use of cc for macOS and OpenBSD
+    "CC=cc" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+    "ASPP=cc -c" {!ocaml-option-32bit:installed & !ocaml-option-musl:installed & (os="openbsd"|os="macos")}
+
+    # Windows ports
+    "--build=x86_64-pc-cygwin" {os = "win32" & arch = "x86_64"}
+    "--build=i686-pc-cygwin" {os = "win32" & arch = "i686"}
+
+    "--host=i686-w64-mingw32" {ocaml-option-mingw:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-w64-mingw32" {ocaml-option-mingw:installed & !ocaml-option-32bit:installed}
+    "--host=i686-pc-windows" {ocaml-option-msvc:installed & ocaml-option-32bit:installed}
+    "--host=x86_64-pc-windows" {ocaml-option-msvc:installed & !ocaml-option-32bit:installed}
+
+    # Compilation with musl
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution!="alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "ASPP=musl-gcc -c" {ocaml-option-musl:installed & os-distribution!="alpine"}
+
+    # Compilation with sanitisers
+    "LDFLAGS=-Wl,--no-as-needed,-ldl" {ocaml-option-leak-sanitizer:installed | (ocaml-option-address-sanitizer:installed & os!="macos")}
+    "CC=gcc -ldl -fsanitize=leak -fno-omit-frame-pointer -O1 -g" {ocaml-option-leak-sanitizer:installed}
+    "CC=gcc -ldl -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os!="macos"}
+    "CC=clang -fsanitize=address -fno-omit-frame-pointer -O1 -g" {ocaml-option-address-sanitizer:installed & os="macos"}
+
+    # 32-bit compilation (Linux)
+    "--host=i386-pc-linux-gnu" {ocaml-option-32bit:installed & os="linux"}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os="linux"}
+    "AS=as --32" {ocaml-option-32bit:installed & os="linux"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os="linux"}
+    "PARTIALLD=ld -r -melf_i386" {ocaml-option-32bit:installed & os="linux"}
+
+    # 32-bit compilation (macOS)
+    "--host=i386-apple-darwin" {ocaml-option-32bit:installed & os="macos"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32" {ocaml-option-32bit:installed & os="macos"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os="macos"}
+    "ASPP=gcc -arch i386 -m32 -c" {ocaml-option-32bit:installed & os="macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [make "install"]
+url {
+  src: "__OCAML_COMPILER_SRC__"
+}
+post-messages: [
+  "A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"
+  {failure & jobs > 1}
+  "You can try installing again including --jobs=1
+   to force a sequential build instead."
+  {failure & jobs > 1 & opam-version >= "2.0.5"}
+]
+conflicts: [ "ocaml-option-fp" "ocaml-option-msvc" ]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-musl"
+  "ocaml-option-leak-sanitizer"
+  "ocaml-option-address-sanitizer"
+  "ocaml-option-static"
+  "ocaml-option-mingw"
+  # TODO: the full behaviour for Cygwin _should_ be that if the Cygwin flexdll is installed and opam's flexdll is not requested,
+  #       then use it; if Cygwin's flexdll is _not_ installed then the opam flexdll package should be pulled in (4.13+) or the
+  #       depext system should cause flexdll to be installed (4.12 and earlier). If opam's flexdll is explicitly requested, then
+  #       OCaml should recompile with it.
+  "flexdll"
+]
+available: os = "win32" | os = "cygwin"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -94,12 +94,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Unix environment ($PATH)
-        if: runner.os != 'Windows'
-        run: |
-          echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
-
-      - name: Pre-setup (robust cache prefix, custom OPAM package for the compiler)
+      - name: Pre-setup ($PATH, cache prefix, custom OPAM package for the compiler)
         id: presetup
         shell: bash
         run: |
@@ -149,6 +144,11 @@ jobs:
           fi
           echo "cache_prefix=$cache_prefix" >> "$GITHUB_OUTPUT"
           cat "$GITHUB_OUTPUT"
+
+          # Override `sudo` on Linux, `brew` on macOS, to speed up installation
+          if [ "$RUNNER_OS" "!=" "Windows" ]; then
+            echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
+          fi
 
       - name: Install OCaml compiler ${{ env.COMPILER }} (Linux / macOS)
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -11,18 +11,18 @@ on:
         description: 'Type of machine + OS on which to run the tests'
         type: string
         default: 'ubuntu-latest'
-      compiler:
-        description: 'Compiler to use'
-        type: string
-        default: 'ocaml-base-compiler.5.0.0'
-      compiler_branch:
-        description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
-        type: string
-        default: ''
       timeout:
         description: 'Timeout'
         type: number
         default: 180
+      dune_profile:
+        description: 'Dune profile to use'
+        type: string
+        default: 'dev'
+      runparam:
+        description: 'OCAMLRUNPARAM to use'
+        type: string
+        default: ''
       only_test:
         description: 'Only test to run (eg “src/array/lin_tests.exe”); whole suite is run if empty'
         type: string
@@ -39,32 +39,32 @@ on:
         description: 'When repeating a test, stop as soon as one test fails'
         type: boolean
         default: false
+      compiler:
+        description: 'Compiler to use'
+        type: string
+        default: 'ocaml-base-compiler.5.0.0'
       compiler_commit:
         description: 'Version (commit) of the OCaml compiler to use'
         type: string
         default: ''
-      dune_profile:
-        description: 'Dune profile to use'
-        type: string
-        default: 'dev'
-      runparam:
-        description: 'OCAMLRUNPARAM to use'
+      compiler_branch:
+        description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
         type: string
         default: ''
 
 jobs:
   build-and-test:
     env:
-      ONLY_TEST: ${{ inputs.only_test }}
-      SEED: ${{ inputs.seed }}
-      REPEATS: ${{ inputs.repeats }}
-      COMPILER:  ${{ inputs.compiler }}
+      QCHECK_MSG_INTERVAL:   '60'
+      DUNE_PROFILE:          ${{ inputs.dune_profile }}
+      OCAMLRUNPARAM:         ${{ inputs.runparam }}
+      ONLY_TEST:             ${{ inputs.only_test }}
+      SEED:                  ${{ inputs.seed }}
+      REPEATS:               ${{ inputs.repeats }}
+      REPEATS_FAILFAST:      ${{ inputs.repeats_failfast }}
+      COMPILER:              ${{ inputs.compiler }}
       OCAML_COMPILER_COMMIT: ${{ inputs.compiler_commit }}
       OCAML_COMPILER_BRANCH: ${{ inputs.compiler_branch }}
-      REPEATS_FAILFAST: ${{ inputs.repeats_failfast }}
-      DUNE_PROFILE: ${{ inputs.dune_profile }}
-      OCAMLRUNPARAM: ${{ inputs.runparam }}
-      QCHECK_MSG_INTERVAL: '60'
 
     runs-on: ${{ inputs.runs_on }}
 

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -51,20 +51,40 @@ on:
         description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
         type: string
         default: ''
+      custom_compiler_version:
+        description: |
+          Version number of the custom OCaml compiler to install (eg 5.1.0+gite4954296e68)
+          This version number will be used by setup-ocaml in its cache key so, if it identifies a precise commit, `compiler_branch` should be empty
+        type: string
+        default: ''
+      custom_compiler_src:
+        description: |
+          Source (URL) of the custom OCaml compiler to install (eg https://github.com/ocaml/ocaml/archive/e4954296e68.tar.gz)
+          Must be set if custom_compiler_version is
+        type: string
+        default: ''
+      custom_ocaml_package_version:
+        description: |
+          Version number of the OCaml OPAM package to use
+          Defaults to custom_compiler_version chunked at [+~-]
+        type: string
+        default: ''
 
 jobs:
   build-and-test:
     env:
-      QCHECK_MSG_INTERVAL:   '60'
-      DUNE_PROFILE:          ${{ inputs.dune_profile }}
-      OCAMLRUNPARAM:         ${{ inputs.runparam }}
-      ONLY_TEST:             ${{ inputs.only_test }}
-      SEED:                  ${{ inputs.seed }}
-      REPEATS:               ${{ inputs.repeats }}
-      REPEATS_FAILFAST:      ${{ inputs.repeats_failfast }}
-      COMPILER:              ${{ inputs.compiler }}
-      OCAML_COMPILER_COMMIT: ${{ inputs.compiler_commit }}
-      OCAML_COMPILER_BRANCH: ${{ inputs.compiler_branch }}
+      QCHECK_MSG_INTERVAL:      '60'
+      DUNE_PROFILE:             ${{ inputs.dune_profile }}
+      OCAMLRUNPARAM:            ${{ inputs.runparam }}
+      ONLY_TEST:                ${{ inputs.only_test }}
+      SEED:                     ${{ inputs.seed }}
+      REPEATS:                  ${{ inputs.repeats }}
+      REPEATS_FAILFAST:         ${{ inputs.repeats_failfast }}
+      COMPILER:                 ${{ inputs.compiler }}
+      OCAML_COMPILER_BRANCH:    ${{ inputs.compiler_branch }}
+      CUSTOM_COMPILER_VERSION:  ${{ inputs.custom_compiler_version }}
+      CUSTOM_COMPILER_SRC:      ${{ inputs.custom_compiler_src }}
+      CUSTOM_OCAML_PKG_VERSION: ${{ inputs.custom_ocaml_package_version }}
 
     runs-on: ${{ inputs.runs_on }}
 
@@ -79,10 +99,49 @@ jobs:
         run: |
           echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
 
-      - name: Pick up a robust cache prefix
-        id: compute_prefix
+      - name: Pre-setup (robust cache prefix, custom OPAM package for the compiler)
+        id: presetup
         shell: bash
         run: |
+          # Generate an OPAM config for a custom compiler
+          if [ -n "$CUSTOM_COMPILER_VERSION" ]; then
+            if [ -z "$CUSTOM_COMPILER_SRC" ]; then
+              echo '::error title=$CUSTOM_COMPILER_SRC not set::$CUSTOM_COMPILER_SRC must be set whenever $CUSTOM_COMPILER_VERSION is'
+              exit 1
+            fi
+            if [ -z "$CUSTOM_OCAML_PKG_VERSION" ]; then
+              CUSTOM_OCAML_PKG_VERSION="${CUSTOM_COMPILER_VERSION%%[~+-]*}"
+            fi
+            if [ "$RUNNER_OS" = "Windows" ]; then
+              OPAMTEMPLATE=.github/opam/ocaml-variants.opam.windows
+            else
+              OPAMTEMPLATE=.github/opam/ocaml-variants.opam.unix
+            fi
+            OPAMDIR=".github/opam/custom/packages/ocaml-variants/ocaml-variants.$CUSTOM_COMPILER_VERSION"
+            mkdir -p "$OPAMDIR"
+            awk -v compiler="$CUSTOM_COMPILER_VERSION"               \
+                -v compilersrc="$CUSTOM_COMPILER_SRC"                \
+                -v ocamlpkg="$CUSTOM_OCAML_PKG_VERSION"              \
+                '{ sub("__OCAML_COMPILER_FULL_VERSION__", compiler); \
+                   sub("__OCAML_COMPILER_SRC__", compilersrc);       \
+                   sub("__OCAML_OPAM_PACKAGE_VERSION__", ocamlpkg);  \
+                   print }' < $OPAMTEMPLATE                          \
+                   > "$OPAMDIR/opam"
+            echo Generated OPAM package configuration:
+            echo ------------------------------------------------
+            cat "$OPAMDIR/opam"
+            echo ------------------------------------------------
+
+            # Reset $COMPILER keeping the options
+            if [ "${COMPILER##*,*}" "=" "$COMPILER" ];
+            then OPTS="";
+            else OPTS=",${COMPILER#*,}";
+            fi
+            echo "COMPILER=ocaml-variants.$CUSTOM_COMPILER_VERSION$OPTS" >> "$GITHUB_ENV"
+            cat "$GITHUB_ENV"
+          fi
+
+          # Pick up a robust cache prefix
           if [ -n "$OCAML_COMPILER_BRANCH" ]; then
             cache_prefix="$(git ls-remote --heads https://github.com/ocaml/ocaml.git "$OCAML_COMPILER_BRANCH" | cut -f 1 | head -n 1)"
           else
@@ -96,11 +155,12 @@ jobs:
         with:
           ocaml-compiler: ${{ env.COMPILER }}
           opam-repositories: |
+            local: file://${{ github.workspace }}/.github/opam/custom
             default: https://github.com/ocaml/opam-repository.git
             override: https://github.com/shym/custom-opam-repository.git
           opam-depext: false
           dune-cache: true
-          cache-prefix: ${{ steps.compute_prefix.outputs.cache_prefix }}
+          cache-prefix: ${{ steps.presetup.outputs.cache_prefix }}
         if: runner.os != 'Windows'
 
       - name: Install OCaml compiler ${{ env.COMPILER }} (Windows)
@@ -108,31 +168,19 @@ jobs:
         with:
           ocaml-compiler: ${{ env.COMPILER }}
           opam-repositories: |
+            local: ${{ github.workspace }}\.github\opam\custom
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
             override: https://github.com/shym/custom-opam-repository.git
             default: https://github.com/fdopen/opam-repository-mingw.git#opam2
             upstream: https://github.com/ocaml/opam-repository.git
           opam-depext: false
-          cache-prefix: ${{ steps.compute_prefix.outputs.cache_prefix }}
+          cache-prefix: ${{ steps.presetup.outputs.cache_prefix }}
         if: runner.os == 'Windows'
 
       - name: Set up macOS environment ($OPAMJOBS)
         if: runner.os == 'macOS'
         run: |
           echo "OPAMJOBS=1" >> $GITHUB_ENV
-
-      - name: Override compiler to a particular commit
-        if: env.OCAML_COMPILER_COMMIT != '' && runner.os != 'Windows'
-        run: |
-          wget "https://github.com/ocaml/ocaml/archive/$OCAML_COMPILER_COMMIT.tar.gz"
-          tar xf "$OCAML_COMPILER_COMMIT.tar.gz"
-          cd "ocaml-$OCAML_COMPILER_COMMIT"
-          opam --cli=2.1 install -y --update-invariant .
-          eval $(opam env)
-          ocamlc -v
-          cd ..
-          gunzip < "$OCAML_COMPILER_COMMIT.tar.gz" | git get-tar-commit-id
-          rm -rf "ocaml-$OCAML_COMPILER_COMMIT"
 
       - name: Install Multicore Tests dependencies
         run: |

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -47,14 +47,16 @@ on:
         description: 'Version (commit) of the OCaml compiler to use'
         type: string
         default: ''
-      compiler_branch:
-        description: 'Source branch of the compiler, to set up caching properly (must be set if CI is not using a tagged release of OCaml)'
+      compiler_git_ref:
+        description: |
+          Git ref (such as "refs/heads/trunk") of the compiler, to set up caching properly when "compiler" is not a unique identifier
+          This ref will be looked up in the upstream "ocaml/ocaml" github repository
         type: string
         default: ''
       custom_compiler_version:
         description: |
           Version number of the custom OCaml compiler to install (eg 5.1.0+gite4954296e68)
-          This version number will be used by setup-ocaml in its cache key so, if it identifies a precise commit, `compiler_branch` should be empty
+          This version number will be used by setup-ocaml in its cache key so, if it identifies a precise commit, `compiler_git_ref` can be empty
         type: string
         default: ''
       custom_compiler_src:
@@ -81,7 +83,7 @@ jobs:
       REPEATS:                  ${{ inputs.repeats }}
       REPEATS_FAILFAST:         ${{ inputs.repeats_failfast }}
       COMPILER:                 ${{ inputs.compiler }}
-      OCAML_COMPILER_BRANCH:    ${{ inputs.compiler_branch }}
+      OCAML_COMPILER_GIT_REF:   ${{ inputs.compiler_git_ref }}
       CUSTOM_COMPILER_VERSION:  ${{ inputs.custom_compiler_version }}
       CUSTOM_COMPILER_SRC:      ${{ inputs.custom_compiler_src }}
       CUSTOM_OCAML_PKG_VERSION: ${{ inputs.custom_ocaml_package_version }}
@@ -137,8 +139,8 @@ jobs:
           fi
 
           # Pick up a robust cache prefix
-          if [ -n "$OCAML_COMPILER_BRANCH" ]; then
-            cache_prefix="$(git ls-remote --heads https://github.com/ocaml/ocaml.git "$OCAML_COMPILER_BRANCH" | cut -f 1 | head -n 1)"
+          if [ -n "$OCAML_COMPILER_GIT_REF" ]; then
+            cache_prefix="$(git ls-remote https://github.com/ocaml/ocaml.git "$OCAML_COMPILER_GIT_REF" | cut -f 1 | head -n 1)"
           else
             cache_prefix=v1
           fi

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -88,6 +88,12 @@ jobs:
       CUSTOM_COMPILER_SRC:      ${{ inputs.custom_compiler_src }}
       CUSTOM_OCAML_PKG_VERSION: ${{ inputs.custom_ocaml_package_version }}
 
+      # For the record, here is how to set up the environment to test
+      # a PR-version of the compiler
+      # OCAML_COMPILER_GIT_REF:   'refs/pull/12345/head'
+      # CUSTOM_COMPILER_VERSION:  '5.1.0+pr12345'
+      # CUSTOM_COMPILER_SRC:      'https://github.com/ocaml/ocaml/archive/refs/pull/12345/head.tar.gz'
+
     runs-on: ${{ inputs.runs_on }}
 
     timeout-minutes: ${{ inputs.timeout }}

--- a/.github/workflows/linux-501-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-501-bytecode-trunk-workflow.yml
@@ -1,0 +1,16 @@
+name: Bytecode trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler:                'ocaml-variants.5.0.1+trunk,ocaml-option-bytecode-only'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'
+      timeout:                 360

--- a/.github/workflows/linux-501-debug-trunk-workflow.yml
+++ b/.github/workflows/linux-501-debug-trunk-workflow.yml
@@ -1,0 +1,18 @@
+name: Linux 5.0 trunk debug
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler:                'ocaml-variants.5.0.1+trunk'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'
+      dune_profile:            'debug-runtime'
+      runparam:                'v=0,V=1'
+      timeout:                 360

--- a/.github/workflows/linux-501-trunk-workflow.yml
+++ b/.github/workflows/linux-501-trunk-workflow.yml
@@ -1,0 +1,16 @@
+name: Linux 5.0 trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler:                'ocaml-variants.5.0.1+trunk'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'
+      timeout:                 360

--- a/.github/workflows/linux-510-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-510-bytecode-trunk-workflow.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.1.0+trunk,ocaml-option-bytecode-only'
-      compiler_branch: 'trunk'
+      compiler_git_ref: refs/heads/trunk
       timeout: 360

--- a/.github/workflows/linux-510-debug-trunk-workflow.yml
+++ b/.github/workflows/linux-510-debug-trunk-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.1.0+trunk'
-      compiler_branch: 'trunk'
+      compiler_git_ref: refs/heads/trunk
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
       timeout: 360

--- a/.github/workflows/linux-510-trunk-workflow.yml
+++ b/.github/workflows/linux-510-trunk-workflow.yml
@@ -7,4 +7,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.1.0+trunk'
-      compiler_branch: 'trunk'
+      compiler_git_ref: refs/heads/trunk

--- a/.github/workflows/macosx-501-trunk-workflow.yml
+++ b/.github/workflows/macosx-501-trunk-workflow.yml
@@ -1,0 +1,16 @@
+name: macOS 5.0 trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on:                 'macos-latest'
+      compiler:                'ocaml-variants.5.0.1+trunk'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'

--- a/.github/workflows/macosx-510-trunk-workflow.yml
+++ b/.github/workflows/macosx-510-trunk-workflow.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.1.0+trunk'
-      compiler_branch: 'trunk'
+      compiler_git_ref: refs/heads/trunk
       runs_on: 'macos-latest'

--- a/.github/workflows/windows-501-trunk-bytecode-workflow.yml
+++ b/.github/workflows/windows-501-trunk-bytecode-workflow.yml
@@ -1,0 +1,17 @@
+name: Win bytecode 5.0 trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on:                 'windows-latest'
+      compiler:                'ocaml-variants.5.0.1+trunk,ocaml-option-mingw,ocaml-option-bytecode-only'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'
+      timeout:                 360

--- a/.github/workflows/windows-501-trunk-workflow.yml
+++ b/.github/workflows/windows-501-trunk-workflow.yml
@@ -1,0 +1,17 @@
+name: Windows 5.0 trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on:                 'windows-latest'
+      compiler:                'ocaml-variants.5.0.1+trunk,ocaml-option-mingw'
+      compiler_git_ref:        'refs/heads/5.0'
+      custom_compiler_version: '5.0.1+trunk'
+      custom_compiler_src:     'https://github.com/ocaml/ocaml/archive/5.0.tar.gz'
+      timeout:                 360

--- a/.github/workflows/windows-510-trunk-workflow.yml
+++ b/.github/workflows/windows-510-trunk-workflow.yml
@@ -8,5 +8,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.1.0,ocaml-option-mingw
-      compiler_branch: trunk
+      compiler_git_ref: refs/heads/trunk
       timeout: 360


### PR DESCRIPTION
Instead of installing a standard compiler package and later updating that opam switch with a new compiler version, generate an opam package configuration into a `local` OPAM repository
This allows to directly install the intended compiler version (a specific compiler commit, for instance) and provides caching of that compiler by setup-ocaml

The last commit of that PR should not be merged into `main` but it allows simply to test the (moving) compiler 5.0.1. (There is an OPAM package that would allow to test that compiler simply on macOS and Linux but not on Windows.)

This hopefully closes #286.