### PR TITLE
Named Lin.Cmd and Lin.Elem arguments

### DIFF
--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -265,8 +265,7 @@ val ( @-> ) :
 (** {1 API description} *)
 
 (** Type and constructor to capture a single function signature *)
-type _ elem = private
-  | Elem : string * ('ftyp, 'r, 's) Fun.fn * 'ftyp -> 's elem
+type !_ elem
 
 type 's api = (int * 's elem) list
 (** The type of module signatures *)


### PR DESCRIPTION
This PR is from @art-w's #266.
It names the individual components of `Lin.Cmd` and `Lin.Elem` which is a good idea(:tm:) independently of #266's proposed optimization.

Thanks @art-w! :smiley::pray: 