### PR TITLE
Minor code clean-up

### DIFF
--- a/lib/STM_sequential.ml
+++ b/lib/STM_sequential.ml
@@ -15,17 +15,16 @@ module Make (Spec: Spec) = struct
       (fun acc (c,r) -> Printf.sprintf "%s\n   %s : %s" acc (Spec.show_cmd c) (show_res r))
       "" trace
 
-  let agree_prop =
-    (fun cs ->
-       assume (cmds_ok Spec.init_state cs);
-       let sut = Spec.init_sut () in (* reset system's state *)
-       let res = check_disagree Spec.init_state sut cs in
-       let ()  = Spec.cleanup sut in
-       match res with
-       | None -> true
-       | Some trace ->
-           Test.fail_reportf "  Results incompatible with model\n%s"
-           @@ print_seq_trace trace)
+  let agree_prop cs =
+    assume (cmds_ok Spec.init_state cs);
+    let sut = Spec.init_sut () in (* reset system's state *)
+    let res = check_disagree Spec.init_state sut cs in
+    let ()  = Spec.cleanup sut in
+    match res with
+    | None -> true
+    | Some trace ->
+      Test.fail_reportf "  Results incompatible with model\n%s"
+      @@ print_seq_trace trace
 
   let agree_test ~count ~name =
     Test.make ~name ~count (arb_cmds Spec.init_state) agree_prop


### PR DESCRIPTION
This little PR changes the 3 remaining property functions to be written using a syntactic function header.
I noticed while merging `main` into #112.

As an added bonus we avoid a little indentation :sweat_smile: 
