### PR TITLE
Skip Dynlink tests under Windows

### DIFF
--- a/src/dynlink/lin_tests_dsl.ml
+++ b/src/dynlink/lin_tests_dsl.ml
@@ -31,6 +31,9 @@ end
 module DynT = Lin_domain.Make(DynConf)
 
 let _ =
-  QCheck_base_runner.run_tests_main [
-    DynT.neg_lin_test ~count:100 ~name:"negative Lin DSL Dynlink test with Domain";
-  ]
+  if Sys.win32 then
+    Printf.printf "negative Lin DSL Dynlink test with Domain disabled under Windows\n\n%!"
+  else
+    QCheck_base_runner.run_tests_main [
+      DynT.neg_lin_test ~count:100 ~name:"negative Lin DSL Dynlink test with Domain";
+    ]


### PR DESCRIPTION
The current implementation of Dynlink under Windows is not thread-safe so skip it until it is fixed