### PR TITLE
Rename the bounds of the tree generators

### DIFF
--- a/src/domain/domain_spawntree.ml
+++ b/src/domain/domain_spawntree.ml
@@ -27,17 +27,17 @@ type cmd =
   (*| Join*)
   | Spawn of cmd list [@@deriving show { with_path = false }]
 
-let gen max_depth max_width =
-  let depth_gen = Gen.int_bound max_depth in
-  let width_gen = Gen.int_bound max_width in
-  Gen.sized_size depth_gen @@ Gen.fix (fun rgen n ->
+let gen max_height max_degree =
+  let height_gen = Gen.int_bound max_height in
+  let degree_gen = Gen.int_bound max_degree in
+  Gen.sized_size height_gen @@ Gen.fix (fun rgen n ->
     match n with
     | 0 -> Gen.oneofl [Incr;Decr]
     | _ ->
       Gen.oneof
         [
           Gen.oneofl [Incr;Decr];
-          Gen.map (fun ls -> Spawn ls) (Gen.list_size width_gen (rgen (n/2)))
+          Gen.map (fun ls -> Spawn ls) (Gen.list_size degree_gen (rgen (n-1)))
         ])
 
 let rec shrink_cmd = function
@@ -63,12 +63,12 @@ let rec dom_interp a = function
     let ds = List.map (fun c -> Domain.spawn (fun () -> dom_interp a c)) cs in
     List.iter Domain.join ds
 
-let t ~max_depth ~max_width = Test.make
+let t ~max_height ~max_degree = Test.make
     ~name:"domain_spawntree - with Atomic"
     ~count:100
     ~retries:10
-    (*~print:show_cmd (gen max_depth max_width)*)
-    (make ~print:show_cmd ~shrink:shrink_cmd (gen max_depth max_width))
+    (*~print:show_cmd (gen max_height max_degree)*)
+    (make ~print:show_cmd ~shrink:shrink_cmd (gen max_height max_degree))
 
     ((*Util.fork_prop_with_timeout 30*) (* forking a fresh process starts afresh, it seems *)
        (fun c ->
@@ -85,4 +85,4 @@ let t ~max_depth ~max_width = Test.make
             else (Printf.printf "Failure \"%s\"\n%!" s; false)
        ))
 ;;
-QCheck_base_runner.run_tests_main [t ~max_depth:20 ~max_width:10]
+QCheck_base_runner.run_tests_main [t ~max_height:5 ~max_degree:10]

--- a/src/thread/thread_createtree.ml
+++ b/src/thread/thread_createtree.ml
@@ -27,17 +27,17 @@ type cmd =
   (*| Join*)
   | Create of cmd list [@@deriving show { with_path = false }]
 
-let gen max_depth max_width =
-  let depth_gen = Gen.int_bound max_depth in
-  let width_gen = Gen.int_bound max_width in
-  Gen.sized_size depth_gen @@ Gen.fix (fun rgen n ->
+let gen max_height max_degree =
+  let height_gen = Gen.int_bound max_height in
+  let degree_gen = Gen.int_bound max_degree in
+  Gen.sized_size height_gen @@ Gen.fix (fun rgen n ->
     match n with
     | 0 -> Gen.oneofl [Incr;Decr]
     | _ ->
       Gen.oneof
         [
           Gen.oneofl [Incr;Decr];
-          Gen.map (fun ls -> Create ls) (Gen.list_size width_gen (rgen (n/2)))
+          Gen.map (fun ls -> Create ls) (Gen.list_size degree_gen (rgen (n-1)))
         ])
 
 let rec shrink_cmd = function
@@ -63,15 +63,15 @@ let rec thread_interp a = function
     let ts = List.map (fun c -> Thread.create (fun () -> thread_interp a c) ()) cs in
     List.iter Thread.join ts
 
-let t ~max_depth ~max_width = Test.make
+let t ~max_height ~max_degree = Test.make
     ~name:"thread_createtree - with Atomic"
     ~count:1000
     ~retries:100
-    (make ~print:show_cmd ~shrink:shrink_cmd (gen max_depth max_width))
+    (make ~print:show_cmd ~shrink:shrink_cmd (gen max_height max_degree))
     (fun c ->
        (*Printf.printf "%s\n%!" (show_cmd c);*)
        let a = Atomic.make 0 in
        let () = thread_interp a c in
        Atomic.get a = interp 0 c)
 ;;
-QCheck_base_runner.run_tests_main [t ~max_depth:20 ~max_width:10]
+QCheck_base_runner.run_tests_main [t ~max_height:5 ~max_degree:10]


### PR DESCRIPTION
After checking in the _Introduction to Algorithms_, use the terms height and degree to bound the size of the generated trees and modify the code to match the definitions of those terms