### PR TITLE
Add opam installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Multicore tests
 [![Windows 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml)
 [![Windows 5.1.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml)
 
-Experimental property-based tests of (parts of) the OCaml multicore compiler.
+Property-based tests of (parts of) the OCaml multicore compiler and run time.
 
 This project contains
 - a randomized test suite of OCaml 5.0, packaged up in `multicoretests.opam`
@@ -28,7 +28,8 @@ This project contains
 All of the above build on [QCheck](https://github.com/c-cube/qcheck),
 a black-box, property-based testing library in the style of QuickCheck.
 
-We are still experimenting with the interfaces, so consider yourself warned.
+The two libraries are young but [already quite
+helpful](https://tarides.com/blog/2022-12-22-ocaml-5-multicore-testing-tools).
 
 
 Installation instructions, and running the tests
@@ -83,7 +84,7 @@ success (ran 2 tests)
 ```
 
 See [src/README.md](src/README.md) for an overview of the current
-(experimental) PBTs of OCaml 5.0.
+PBTs of OCaml 5.0.
 
 
 A Linearization Tester

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ opam update
 opam switch create 5.0.0
 ```
 
-Using `opam` you can now `pin` and install them as follows:
+Using `opam` you can install the two testing libraries by running one
+of the following commands:
+```
+opam install qcheck-lin
+opam install qcheck-stm
+```
+
+Bleeding edge users can `pin` and install the latest `main` as follows:
 ```
 opam pin -y https://github.com/ocaml-multicore/multicoretests.git#main
 ```
@@ -54,7 +61,8 @@ Using the `STM` library in sequential mode requires the dependency
 `(libraries qcheck-stm.sequential)` and the parallel mode similarly
 requires the dependency `(libraries qcheck-stm.domain)`.
 
-
+We have not released the test suite on the [opam
+repository](https://github.com/ocaml/opam-repository) at this point.
 The test suite can be built and run from a clone of this repository
 with the following commands:
 ```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ opam update
 opam switch create 5.0.0
 ```
 
-Using `opam` you can install the two testing libraries by running one
-of the following commands:
+The two testing libraries are available as packages `qcheck-lin`
+and `qcheck-stm` from the opam repository and can be installed in
+the usual way:
 ```
 opam install qcheck-lin
 opam install qcheck-stm


### PR DESCRIPTION
This PR
- clarifies `opam` installation steps to reflect that we've now released the two libraries and
- tones down the 'experimental' signals in the README text