### PR TITLE
CI: Install 32-bit libzstd for 32-bit trunk runs

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -112,6 +112,12 @@ jobs:
         id: presetup
         shell: bash
         run: |
+          if [ "${COMPILER##*trunk*32bit}" = "" ]; then
+            sudo dpkg --add-architecture i386
+            sudo apt-get update
+            echo "LDFLAGS=-L/usr/lib/i386-linux-gnu/" >> $GITHUB_ENV
+          fi
+
           # Generate an OPAM config for a custom compiler
           if [ -n "$CUSTOM_COMPILER_VERSION" ]; then
             if [ -z "$CUSTOM_COMPILER_SRC" ]; then

--- a/.github/workflows/linux-510-32bit-trunk-workflow.yml
+++ b/.github/workflows/linux-510-32bit-trunk-workflow.yml
@@ -9,4 +9,4 @@ jobs:
       compiler: 'ocaml-variants.5.1.0+trunk,ocaml-option-32bit'
       compiler_git_ref: refs/heads/trunk
       timeout: 360
-      override_apt_install: bubblewrap gcc-multilib g++-multilib
+      override_apt_install: bubblewrap gcc-multilib g++-multilib libzstd1:i386 libzstd-dev:i386


### PR DESCRIPTION
Trunk OCaml now uses libzstd to compress during marshalling so we explicitly install the 32-bit version of the library in 32-bit runs and modify LDFLAGS to ensure that library is found during linking