### PR TITLE
Add (and use) a runner wrapping every test, to improve error reporting

### DIFF
--- a/src/array/dune
+++ b/src/array/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -16,7 +16,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/array/%{test} from the test suite\n\n"))
 )
 
@@ -25,5 +25,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -8,7 +8,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 ;; Linearization tests of Atomic, utilizing ppx_deriving_qcheck
@@ -20,7 +20,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/atomic/%{test} from the test suite\n\n"))
 )
 
@@ -29,5 +29,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:stm_tests.exe}))
  (action (echo "Skipping src/bigarray/%{test} from the test suite\n\n"))
 )
 
@@ -15,5 +15,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/buffer/dune
+++ b/src/buffer/dune
@@ -6,5 +6,5 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )

--- a/src/bytes/dune
+++ b/src/bytes/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -14,5 +14,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -8,7 +8,7 @@
  (package multicoretests)
  (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:domain_joingraph.exe}))
 )
 
 (test
@@ -17,5 +17,5 @@
  (package multicoretests)
  (libraries util qcheck-core qcheck-core.runner)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:domain_spawntree.exe}))
 )

--- a/src/dynlink/dune
+++ b/src/dynlink/dune
@@ -15,5 +15,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain dynlink libA libB)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/ephemeron/dune
+++ b/src/ephemeron/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -14,5 +14,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/floatarray/dune
+++ b/src/floatarray/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -14,5 +14,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -16,7 +16,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/hashtbl/%{test} from the test suite\n\n"))
 )
 
@@ -25,5 +25,5 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )

--- a/src/io/dune
+++ b/src/io/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.domain)
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/io/%{test} from the test suite\n\n"))
 )
 
@@ -23,7 +23,7 @@
  (package multicoretests)
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.domain lin_tests_dsl_common_io)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl_domain.exe}))
 )
 
 (test
@@ -32,6 +32,6 @@
  (package multicoretests)
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.thread lin_tests_dsl_common_io)
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests_dsl_thread.exe}))
  (action (echo "Skipping src/io/%{test} from the test suite\n\n"))
 )

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -15,7 +15,7 @@
  (package multicoretests)
  (libraries qcheck-lin.domain)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
 )
 
@@ -24,6 +24,6 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests_dsl.exe}))
  (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
 )

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -13,7 +13,7 @@
  (modules stm_tests_sequential_ref)
  (package multicoretests)
  (libraries stm_tests_spec_ref qcheck-stm.sequential)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests_sequential_ref.exe}))
 )
 
 (test
@@ -21,7 +21,7 @@
  (modules stm_tests_domain_ref)
  (package multicoretests)
  (libraries stm_tests_spec_ref qcheck-stm.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests_domain_ref.exe}))
 )
 
 (test
@@ -29,7 +29,7 @@
  (modules stm_tests_thread_ref)
  (package multicoretests)
  (libraries stm_tests_spec_ref qcheck-stm.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests_thread_ref.exe}))
 )
 
 (library
@@ -44,7 +44,7 @@
  (package multicoretests)
  (libraries CList qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests_conclist.exe}))
 )
 
 ;; Linearization tests of ref and Clist with Lin
@@ -70,7 +70,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl_domain.exe}))
 )
 
 (test
@@ -79,7 +79,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common qcheck-lin.thread)
- ; (action (run %{test} --verbose))
+ ; (action (run runner %{dep:lin_tests_dsl_thread.exe}))
  (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
 )
 
@@ -89,7 +89,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_dsl_common qcheck-lin.effect)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl_effect.exe}))
 )
 
 ;; Linearization tests of ref and Clist with Lin.Internal
@@ -100,17 +100,26 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_common)
-  ; (action (run %{test} --verbose))
+  ; (action (run runner %{dep:lin_tests_domain.exe}))
  (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
 )
 
-(tests
- (names lin_tests_thread_ref lin_tests_thread_conclist)
- (modules lin_tests_thread_ref lin_tests_thread_conclist)
+(test
+ (name lin_tests_thread_ref)
+ (modules lin_tests_thread_ref)
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_thread_ref.exe}))
+)
+
+(test
+ (name lin_tests_thread_conclist)
+ (modules lin_tests_thread_conclist)
+ (package multicoretests)
+ (flags (:standard -w -27))
+ (libraries lin_tests_common qcheck-lin.thread)
+ (action (run runner %{dep:lin_tests_thread_conclist.exe}))
 )
 
 (test
@@ -120,6 +129,6 @@
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.effect)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
-  ; (action (run ./%{deps} --verbose))
+  ; (action (run runner %{dep:lin_tests_effect.exe}))
  (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
 )

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )
 
 (test
@@ -16,6 +16,6 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
- ;(action (run %{test} --verbose))
+ ;(action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/queue/%{test} from the test suite\n\n"))
 )

--- a/src/semaphore/dune
+++ b/src/semaphore/dune
@@ -6,5 +6,5 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )
 
 (test
@@ -16,7 +16,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
-  ; (action (run %{test} --verbose))
+  ; (action (run runner %{dep:lin_tests.exe}))
  (action (echo "Skipping src/stack/%{test} from the test suite\n\n"))
 )
 

--- a/src/sys/dune
+++ b/src/sys/dune
@@ -6,5 +6,5 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )

--- a/src/thread/dune
+++ b/src/thread/dune
@@ -8,7 +8,7 @@
  (package multicoretests)
  (libraries threads qcheck-core util)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:thread_joingraph.exe}))
 )
 
 (test
@@ -17,5 +17,5 @@
  (package multicoretests)
  (libraries threads qcheck-core util)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:thread_createtree.exe}))
 )

--- a/src/threadomain/dune
+++ b/src/threadomain/dune
@@ -6,5 +6,5 @@
  (package multicoretests)
  (libraries util qcheck-core threads)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:threadomain.exe}))
 )

--- a/src/weak/dune
+++ b/src/weak/dune
@@ -6,7 +6,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests.exe}))
 )
 
 (test
@@ -15,7 +15,7 @@
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
  (preprocess (pps ppx_deriving.show))
- (action (run %{test} --verbose))
+ (action (run runner %{dep:stm_tests_hashset.exe}))
 )
 
 (test
@@ -23,7 +23,7 @@
  (modules lin_tests_dsl)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl.exe}))
 )
 
 (test
@@ -31,5 +31,5 @@
  (modules lin_tests_dsl_hashset)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
+ (action (run runner %{dep:lin_tests_dsl_hashset.exe}))
 )

--- a/tools/dune
+++ b/tools/dune
@@ -1,0 +1,5 @@
+(executable
+ (name runner)
+ (public_name runner)
+ (package multicoretests)
+ (libraries unix))

--- a/tools/runner.ml
+++ b/tools/runner.ml
@@ -1,0 +1,131 @@
+(* Custom runner for the tests so that:
+   - error codes on Windows are turned back into their Unix meaninrgs
+   - anchors are added to CI logs with relevant information *)
+
+let use_github_anchors = Sys.getenv_opt "CI" = Some "true"
+
+let signals =
+  let open Sys in
+  [
+    (sigabrt, "ABRT");
+    (sigalrm, "ALRM");
+    (sigfpe, "FPE");
+    (sighup, "HUP");
+    (sigill, "ILL");
+    (sigint, "INT");
+    (sigkill, "KILL");
+    (sigpipe, "PIPE");
+    (sigquit, "QUIT");
+    (sigsegv, "SEGV");
+    (sigterm, "TERM");
+    (sigusr1, "USR1");
+    (sigusr2, "USR2");
+    (sigchld, "CHLD");
+    (sigcont, "CONT");
+    (sigstop, "STOP");
+    (sigtstp, "TSTP");
+    (sigttin, "TTIN");
+    (sigttou, "TTOU");
+    (sigvtalrm, "VTALRM");
+    (sigprof, "PROF");
+    (sigbus, "BUS");
+    (sigpoll, "POLL");
+    (sigsys, "SYS");
+    (sigtrap, "TRAP");
+    (sigurg, "URG");
+    (sigxcpu, "XCPU");
+    (sigxfsz, "XFSZ");
+  ]
+
+let error fmt cmd msg =
+  if use_github_anchors then
+    Format.fprintf fmt "\n::error title=%s in %s::%s in %s\n%!" msg cmd msg cmd
+  else Format.fprintf fmt "\nError: %s in %s\n%!" msg cmd
+
+let pp_status_unix fmt cmd status =
+  let open Unix in
+  (match status with
+  | WEXITED 0 -> ()
+  | WEXITED s -> error fmt cmd (Printf.sprintf "Exit %d" s)
+  | WSIGNALED s ->
+      let msg =
+        match List.assoc_opt s signals with
+        | Some signal -> "Signal " ^ signal
+        | None -> Printf.sprintf "Unknown signal %d" s
+      in
+      error fmt cmd msg
+  | WSTOPPED s ->
+      let msg =
+        match List.assoc_opt s signals with
+        | Some signal -> "Stop with signal " ^ signal
+        | None -> Printf.sprintf "Stop with unknown signal %d" s
+      in
+      error fmt cmd msg);
+  status = WEXITED 0
+
+(* Under Windows, there is no such thing as terminating due to a
+   signal, so the WSIGNALED and WSTOPPED cases are dead code.
+
+   The strategy is to use conventional exit values (which are 32-bit,
+   not just 8-bit like on Unix) to describe the cause.
+   The documentation of ”NTSTATUS Values” list {e many} cases, too
+   many to handle them all. This is where the value akin to SEGV comes
+   from. Other special cases will be caught as they appear.
+
+   The value used to match ABRT comes from the code of the abort
+   function in the standard library.
+
+   {{:https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/596a1078-e883-4972-9bbc-49e60bebca55}NTSTATUS Values}
+*)
+let pp_status_win fmt cmd status =
+  let open Unix in
+  (match status with
+  | WEXITED 0 -> ()
+  | WEXITED 3 -> error fmt cmd "Signal ABRT"
+  | WEXITED -1073741819 (* 0xC0000005 *) -> error fmt cmd "Signal SEGV"
+  | WEXITED s -> error fmt cmd (Printf.sprintf "Exit %d" s)
+  (* Those last 2 cases are dead code on Windows *)
+  | WSIGNALED s ->
+      let msg =
+        match List.assoc_opt s signals with
+        | Some signal -> "Signal " ^ signal
+        | None -> Printf.sprintf "Unknown signal %d" s
+      in
+      error fmt cmd msg
+  | WSTOPPED s ->
+      let msg =
+        match List.assoc_opt s signals with
+        | Some signal -> "Stop with signal " ^ signal
+        | None -> Printf.sprintf "Stop with unknown signal %d" s
+      in
+      error fmt cmd msg);
+  status = WEXITED 0
+
+let pp_status = if Sys.win32 then pp_status_win else pp_status_unix
+
+let run ofmt efmt argv =
+  let argv =
+    match argv with [| cmd |] -> [| cmd; "--verbose" |] | _ -> argv
+  in
+  let testdir = Filename.basename (Sys.getcwd ()) in
+  let exe, cmd =
+    if Filename.is_implicit argv.(0) then
+      ( Filename.concat Filename.current_dir_name argv.(0),
+        Filename.concat testdir argv.(0) )
+    else (argv.(0), argv.(0))
+  in
+  let cmdline = String.concat " " (Array.to_list argv) in
+  Format.fprintf ofmt "\n\nStarting (in %s) %s:\n%!" testdir cmdline;
+  let pid = Unix.(create_process exe argv stdin stdout stderr) in
+  let _, status = Unix.waitpid [] pid in
+  pp_status efmt cmd status
+
+let _ =
+  let open Format in
+  if Array.length Sys.argv < 2 then (
+    fprintf err_formatter
+      "\nError: %s expects the\n  command to run as argument\n%!" Sys.argv.(0);
+    exit 1);
+  let cmd = Array.sub Sys.argv 1 (Array.length Sys.argv - 1) in
+  let success = run std_formatter err_formatter cmd in
+  if not success then exit 1


### PR DESCRIPTION
This supersedes #205, providing a custom runner written in OCaml

Add a custom runner that allows to display the result of a test in the same way on Unix and Windows (by mapping Windows error codes to their equivalent result on Unix)
It also uses GitHub CI formats when available so that test failures are referenced as such at their positions in the logs

As it is written in OCaml (rather than bash), it opens some possible improvements:
- create a summary of all timings,
- use per-test timeouts (the same timeout for all tests? or a custom timeout for some tests that we expect to run a long time?),
- ensure that the global timeout is never reached by stopping the test suite a couple of minutes before, so that the last steps (post-*) can run 