### PR TITLE
Add workflows to test OCaml trunk on Cygwin

### DIFF
--- a/.github/opam/ocaml-variants.opam.unix
+++ b/.github/opam/ocaml-variants.opam.unix
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "ocaml-variants"
 synopsis: "Custom compiler __OCAML_COMPILER_FULL_VERSION__"
 maintainer: "platform@lists.ocaml.org"
 authors: [

--- a/.github/opam/ocaml-variants.opam.windows
+++ b/.github/opam/ocaml-variants.opam.windows
@@ -14,7 +14,8 @@ depends: [
   "base-domains" {post}
   "base-nnp" {post}
   "ocaml-option-bytecode-only" {arch != "arm64" & arch != "x86_64"}
-  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {post})
+  "conf-flexdll" {os = "cygwin"}
+  ("flexdll" {os = "win32"} | "flexdll-bin" {os = "win32"} & "flexlink" {os = "win32" & post})
 ]
 conflict-class: "ocaml-core-compiler"
 flags: compiler
@@ -52,6 +53,8 @@ build: [
     # Windows ports
     "--build=x86_64-pc-cygwin" {os = "win32" & arch = "x86_64"}
     "--build=i686-pc-cygwin" {os = "win32" & arch = "i686"}
+    # Fix on Cygwin
+    "--enable-imprecise-c99-float-ops" {os = "cygwin"}
 
     "--host=i686-w64-mingw32" {ocaml-option-mingw:installed & ocaml-option-32bit:installed}
     "--host=x86_64-w64-mingw32" {ocaml-option-mingw:installed & !ocaml-option-32bit:installed}

--- a/.github/opam/ocaml-variants.opam.windows
+++ b/.github/opam/ocaml-variants.opam.windows
@@ -1,5 +1,4 @@
 opam-version: "2.0"
-name: "ocaml-variants"
 synopsis: "Custom compiler __OCAML_COMPILER_FULL_VERSION__"
 license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 maintainer: "platform@lists.ocaml.org"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -43,6 +43,10 @@ on:
         description: 'When repeating a test, stop as soon as one test fails'
         type: boolean
         default: false
+      subsuite:
+        description: 'Directories which should be taken as part of the test suite'
+        type: string
+        default: 'src'
       compiler:
         description: 'Compiler to use'
         type: string
@@ -91,6 +95,7 @@ jobs:
       SEED:                     ${{ inputs.seed }}
       REPEATS:                  ${{ inputs.repeats }}
       REPEATS_FAILFAST:         ${{ inputs.repeats_failfast }}
+      SUBSUITE:                 ${{ inputs.subsuite }}
       COMPILER:                 ${{ inputs.compiler }}
       OCAML_COMPILER_GIT_REF:   ${{ inputs.compiler_git_ref }}
       CUSTOM_COMPILER_VERSION:  ${{ inputs.custom_compiler_version }}
@@ -301,9 +306,13 @@ jobs:
         run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice test/
         if: env.ONLY_TEST == ''
 
-      - name: Run the multicore test suite
-        run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice src/
-        if: env.ONLY_TEST == ''
+      - name: Run the multicore test suite (Linux / macOS)
+        run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice $SUBSUITE
+        if: "runner.os != 'Windows' && env.ONLY_TEST == ''"
+
+      - name: Run the multicore test suite (Windows / Cygwin)
+        run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice @(-Split $Env:SUBSUITE)
+        if: "runner.os == 'Windows' && env.ONLY_TEST == ''"
 
       - name: Run only one test (Linux / macOS)
         run: |

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -11,6 +11,10 @@ on:
         description: 'Type of machine + OS on which to run the tests'
         type: string
         default: 'ubuntu-latest'
+      cygwin:
+        description: 'Whether Cygwin should be used (on Windows, of course)'
+        type: boolean
+        default: false
       timeout:
         description: 'Timeout'
         type: number
@@ -105,6 +109,19 @@ jobs:
     timeout-minutes: ${{ inputs.timeout }}
 
     steps:
+      - name: Configure environment (Cygwin)
+        run: |
+          # Ensure that .expected files are not modified by check out
+          # as, in Cygwin, the .expected should use LF line endings,
+          # rather than Windows’ CRLF
+          git config --global core.autocrlf input
+
+          # Set up OPAM environment variables for the particular
+          # Cygwin case
+          echo OPAMYES=1 >> $env:GITHUB_ENV
+          echo OPAMROOT=/cygdrive/d/opam >> $env:GITHUB_ENV
+        if: "runner.os == 'Windows' && inputs.cygwin"
+
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -170,6 +187,9 @@ jobs:
             echo "PATH=$GITHUB_WORKSPACE/.github/bin:$PATH" >> $GITHUB_ENV
           fi
 
+          # Save pristine PATH for cache action (Cygwin messes it up)
+          echo "cache_path=$PATH" >> "$GITHUB_OUTPUT"
+
       - name: Install OCaml compiler ${{ env.COMPILER }} (Linux / macOS)
         uses: ocaml/setup-ocaml@v2
         with:
@@ -195,7 +215,56 @@ jobs:
             upstream: https://github.com/ocaml/opam-repository.git
           opam-depext: false
           cache-prefix: ${{ steps.presetup.outputs.cache_prefix }}
-        if: runner.os == 'Windows'
+        if: "runner.os == 'Windows' && !inputs.cygwin"
+
+      - name: Restore Cygwin packages (Cygwin)
+        uses: actions/cache/restore@v3
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            C:\cygwin-packages
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
+        if: "runner.os == 'Windows' && inputs.cygwin"
+
+      - name: Install Cygwin (in particular OPAM) (Cygwin)
+        uses: cygwin/cygwin-install-action@v3
+        with:
+          packages: opam
+          install-dir: 'D:\cygwin'
+        if: "runner.os == 'Windows' && inputs.cygwin"
+
+      - name: Save Cygwin packages (Cygwin)
+        uses: actions/cache/save@v3
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            C:\cygwin-packages
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
+        if: "runner.os == 'Windows' && inputs.cygwin"
+
+      - name: Restore OPAM state (Cygwin)
+        uses: actions/cache/restore@v3
+        id: cache_opam
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            D:\opam
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
+        if: "runner.os == 'Windows' && inputs.cygwin"
+
+      - name: Install OCaml compiler ${{ env.COMPILER }} (Cygwin)
+        run: |
+          opam init --disable-sandboxing --auto-setup --bare
+          opam repository add --all main "https://github.com/ocaml/opam-repository.git"
+          opam repository add --all windows "https://github.com/fdopen/opam-repository-mingw.git#opam2"
+          opam repository add --all override "https://github.com/shym/custom-opam-repository.git"
+          opam repository add --all dra27 "https://github.com/dra27/opam-repository.git#windows-5.0"
+          opam repository add --all local "./.github/opam/custom/"
+          opam switch create default --repositories=dra27,override,windows,main --packages "${env:COMPILER}"
+        if: "runner.os == 'Windows' && inputs.cygwin && steps.cache_opam.outputs.cache-hit != 'true'"
 
       - name: Set up macOS environment ($OPAMJOBS)
         if: runner.os == 'macOS'
@@ -205,6 +274,7 @@ jobs:
       - name: Install Multicore Tests dependencies
         run: |
           opam install . --deps-only --with-test
+          opam clean --all-switches --unused-repositories --logs --download-cache --repo-cache
 
       - name: Show configuration
         run: |
@@ -212,6 +282,16 @@ jobs:
           opam config list
           opam exec -- dune printenv
           opam list --columns=name,installed-version,repository,synopsis-or-target
+
+      - name: Save OPAM state (Cygwin)
+        uses: actions/cache/save@v3
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            D:\opam
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
+        if: "runner.os == 'Windows' && inputs.cygwin"
 
       - name: Build the test suite
         run: opam exec -- dune build

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -12,9 +12,13 @@ on:
         type: string
         default: 'ubuntu-latest'
       cygwin:
-        description: 'Whether Cygwin should be used (on Windows, of course)'
-        type: boolean
-        default: false
+        description: >
+          Whether Cygwin should be used on Windows (empty if not), and
+          how ('waiter' will sleep 1 hour if the cache is not
+          initialized when it starts, 'initializer' will assume it has
+          the role of creating that cache)
+        type: string
+        default: ''
       timeout:
         description: 'Timeout'
         type: number
@@ -125,7 +129,7 @@ jobs:
           # Cygwin case
           echo OPAMYES=1 >> $env:GITHUB_ENV
           echo OPAMROOT=/cygdrive/d/opam >> $env:GITHUB_ENV
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin != ''"
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -220,9 +224,24 @@ jobs:
             upstream: https://github.com/ocaml/opam-repository.git
           opam-depext: false
           cache-prefix: ${{ steps.presetup.outputs.cache_prefix }}
-        if: "runner.os == 'Windows' && !inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin == ''"
 
       - name: Restore Cygwin packages (Cygwin)
+        uses: actions/cache/restore@v3
+        id: cache_cygwin
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            C:\cygwin-packages
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
+        if: "runner.os == 'Windows' && inputs.cygwin != ''"
+
+      - name: Wait for the cache (Cygwin)
+        run: sleep 3600
+        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_cygwin.outputs.cache-hit != 'true'"
+
+      - name: Retry restoring Cygwin packages (Cygwin)
         uses: actions/cache/restore@v3
         env:
           PATH: ${{ steps.presetup.outputs.cache_path }}
@@ -230,14 +249,14 @@ jobs:
           path: |
             C:\cygwin-packages
           key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_cygwin.outputs.cache-hit != 'true'"
 
       - name: Install Cygwin (in particular OPAM) (Cygwin)
         uses: cygwin/cygwin-install-action@v3
         with:
           packages: opam
           install-dir: 'D:\cygwin'
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin != ''"
 
       - name: Save Cygwin packages (Cygwin)
         uses: actions/cache/save@v3
@@ -247,7 +266,7 @@ jobs:
           path: |
             C:\cygwin-packages
           key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin == 'initializer'"
 
       - name: Restore OPAM state (Cygwin)
         uses: actions/cache/restore@v3
@@ -258,7 +277,7 @@ jobs:
           path: |
             D:\opam
           key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin != ''"
 
       - name: Install OCaml compiler ${{ env.COMPILER }} (Cygwin)
         run: |
@@ -269,7 +288,7 @@ jobs:
           opam repository add --all dra27 "https://github.com/dra27/opam-repository.git#windows-5.0"
           opam repository add --all local "./.github/opam/custom/"
           opam switch create default --repositories=dra27,override,windows,main --packages "${env:COMPILER}"
-        if: "runner.os == 'Windows' && inputs.cygwin && steps.cache_opam.outputs.cache-hit != 'true'"
+        if: "runner.os == 'Windows' && inputs.cygwin != '' && steps.cache_opam.outputs.cache-hit != 'true'"
 
       - name: Set up macOS environment ($OPAMJOBS)
         if: runner.os == 'macOS'
@@ -296,7 +315,7 @@ jobs:
           path: |
             D:\opam
           key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin"
+        if: "runner.os == 'Windows' && inputs.cygwin == 'initializer'"
 
       - name: Build the test suite
         run: opam exec -- dune build

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -234,22 +234,8 @@ jobs:
         with:
           path: |
             C:\cygwin-packages
-          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
+          key: cygwin-packages-opam-2.0.7-1
         if: "runner.os == 'Windows' && inputs.cygwin != ''"
-
-      - name: Wait for the cache (Cygwin)
-        run: sleep 3600
-        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_cygwin.outputs.cache-hit != 'true'"
-
-      - name: Retry restoring Cygwin packages (Cygwin)
-        uses: actions/cache/restore@v3
-        env:
-          PATH: ${{ steps.presetup.outputs.cache_path }}
-        with:
-          path: |
-            C:\cygwin-packages
-          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_cygwin.outputs.cache-hit != 'true'"
 
       - name: Install Cygwin (in particular OPAM) (Cygwin)
         uses: cygwin/cygwin-install-action@v3
@@ -265,8 +251,8 @@ jobs:
         with:
           path: |
             C:\cygwin-packages
-          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-packages-${{ env.COMPILER }}
-        if: "runner.os == 'Windows' && inputs.cygwin == 'initializer'"
+          key: cygwin-packages-opam-2.0.7-1
+        if: "runner.os == 'Windows' && inputs.cygwin == 'initializer' && steps.cache_cygwin.outputs.cache-hit != 'true'"
 
       - name: Restore OPAM state (Cygwin)
         uses: actions/cache/restore@v3
@@ -279,6 +265,21 @@ jobs:
           key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
         if: "runner.os == 'Windows' && inputs.cygwin != ''"
 
+      - name: Wait for the cache (Cygwin)
+        run: sleep 3600
+        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_opam.outputs.cache-hit != 'true'"
+
+      - name: Retry restoring OPAM packages (Cygwin)
+        uses: actions/cache/restore@v3
+        env:
+          PATH: ${{ steps.presetup.outputs.cache_path }}
+        with:
+          path: |
+            D:\opam
+          key: ${{ steps.presetup.outputs.cache_prefix }}-cygwin-opam-${{ env.COMPILER }}
+          fail-on-cache-miss: true
+        if: "runner.os == 'Windows' && inputs.cygwin == 'waiter' && steps.cache_opam.outputs.cache-hit != 'true'"
+
       - name: Install OCaml compiler ${{ env.COMPILER }} (Cygwin)
         run: |
           opam init --disable-sandboxing --auto-setup --bare
@@ -288,7 +289,7 @@ jobs:
           opam repository add --all dra27 "https://github.com/dra27/opam-repository.git#windows-5.0"
           opam repository add --all local "./.github/opam/custom/"
           opam switch create default --repositories=dra27,override,windows,main --packages "${env:COMPILER}"
-        if: "runner.os == 'Windows' && inputs.cygwin != '' && steps.cache_opam.outputs.cache-hit != 'true'"
+        if: "runner.os == 'Windows' && inputs.cygwin == 'initializer' && steps.cache_opam.outputs.cache-hit != 'true'"
 
       - name: Set up macOS environment ($OPAMJOBS)
         if: runner.os == 'macOS'

--- a/.github/workflows/cygwin-510-trunk-workflow.yml
+++ b/.github/workflows/cygwin-510-trunk-workflow.yml
@@ -1,0 +1,13 @@
+name: Cygwin trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.1.0
+      cygwin: true
+      compiler_git_ref: refs/heads/trunk
+      timeout: 360

--- a/.github/workflows/cygwin1-510-trunk-workflow.yml
+++ b/.github/workflows/cygwin1-510-trunk-workflow.yml
@@ -1,0 +1,14 @@
+name: Cygwin trunk (1)
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.1.0
+      cygwin: initializer
+      compiler_git_ref: refs/heads/trunk
+      timeout: 360
+      subsuite: src/array src/atomic src/bigarray src/buffer src/bytes src/domain src/dynlink src/ephemeron src/floatarray src/hashtbl src/io

--- a/.github/workflows/cygwin2-510-trunk-workflow.yml
+++ b/.github/workflows/cygwin2-510-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Cygwin trunk
+name: Cygwin trunk (2)
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -8,6 +8,7 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.1.0
-      cygwin: true
+      cygwin: waiter
       compiler_git_ref: refs/heads/trunk
       timeout: 360
+      subsuite: src/lazy src/neg_tests src/queue src/semaphore src/stack src/statistics src/sys src/thread src/threadomain src/weak

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Multicore tests
 [![Windows 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml)
 [![Windows 5.1.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml)
 
+[![Cygwin trunk (1)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin1-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin1-510-trunk-workflow.yml)
+[![Cygwin trunk (2)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin2-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin2-510-trunk-workflow.yml)
+
 Property-based tests of (parts of) the OCaml multicore compiler and run time.
 
 This project contains

--- a/src/sys/stm_tests.ml
+++ b/src/sys/stm_tests.ml
@@ -185,6 +185,7 @@ struct
 
   let cleanup _ =
     match Sys.os_type with
+    | "Cygwin"
     | "Unix"  -> ignore (Sys.command ("rm -r " ^ Filename.quote sandbox_root))
     | "Win32" -> ignore (Sys.command ("rd /s /q " ^ Filename.quote sandbox_root))
     | v -> failwith ("Sys tests not working with " ^ v)
@@ -285,6 +286,7 @@ struct
              Permission denied: seen on Windows *)
       and msg_path_not_dir =
         match Sys.os_type with
+        | "Cygwin"
         | "Unix"  -> "Not a directory"
         | "Win32" -> "No such file or directory"
         | v -> failwith ("Sys tests not working with " ^ v)


### PR DESCRIPTION
This branch is _finally_ getting mergeable.
Unfortunately, running the test suite on Cygwin takes so much time that it never fits into a single 6-hour run, so this PR proposes to add two workflows, each handling about half of the tests.

Still, I’d like to avoid repeating work as much as possible, in particular building twice the compiler and the dependencies (which take about 50 minutes in all the test rounds I ran...). So the way it is currently split up is:
- one workflow (Cygwin 1), with its `cygwin` input variable set to “initializer”, will build the compiler and the dependencies and create a cache entry with all that as soon as they are ready, before starting the tests _per se_,
- the other workflow (Cygwin 2), the “waiter”, will sleep for an hour if it does not find the cache entry it hopes for and then retry to fetch from the cache; if it fails again, it will fail the whole run (rather than try to build the compiler after already one hour of timeout lost).

Another possible (if I understood correctly github docs) strategy would be to set up the second workflow as triggered only when the first one completes. It would be slower but it would be simpler and quite possibly more robust (if the two workflows are not started at the same time, for instance when the runners are quite busy, the waiting strategy will fail).
@jmid: do you have any preference between those two options?