### PR TITLE
Escape bytes when printing in STM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - ensure `cleanup` is run in the presence of exceptions in
   - `STM_sequential.agree_prop` and `STM_domain.agree_prop_par`
   - `Lin_thread.lin_prop` and `Lin_effect.lin_prop`
+- #312: Escape and quote `bytes` printed with `STM`'s `bytes` combinator
 
 ## 0.1.1
 

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -31,7 +31,7 @@ let int32 = (Int32, Int32.to_string)
 let int64 = (Int64, Int64.to_string)
 let float = (Float, Float.to_string)
 let string = (String, fun s -> Printf.sprintf "%S" s)
-let bytes = (Bytes, fun b -> QCheck.Print.string (Bytes.to_string b))
+let bytes = (Bytes, fun b -> Printf.sprintf "%S" (Bytes.to_string b))
 let option spec =
   let (ty,show) = spec in
   (Option ty, QCheck.Print.option show)


### PR DESCRIPTION
Same problem as in #281 for `bytes` (see for instance this [run](https://github.com/shym/multicoretests/actions/runs/4469161241/jobs/7850880362#step:21:947)), so same solution.