### PR TITLE
Disable the negative Out_channel tests on Windows and macOS

### DIFF
--- a/src/io/dune
+++ b/src/io/dune
@@ -23,7 +23,9 @@
  (package multicoretests)
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.domain lin_tests_dsl_common_io)
- (action (run %{test} --verbose))
+ (action
+  (setenv OCAML_SYSTEM %{system}
+   (run %{test} --verbose)))
 )
 
 (test

--- a/src/io/lin_tests_dsl_domain.ml
+++ b/src/io/lin_tests_dsl_domain.ml
@@ -7,8 +7,14 @@ open Lin_tests_dsl_common_io.Lin_tests_dsl_common
 module IC_domain = Lin_domain.Make(ICConf)
 module OC_domain = Lin_domain.Make(OCConf)
 
-let _ =
-  QCheck_base_runner.run_tests_main [
-    IC_domain.neg_lin_test ~count:1000 ~name:"Lin DSL In_channel test with Domain";
+let tests =
+  IC_domain.neg_lin_test ~count:1000 ~name:"Lin DSL In_channel test with Domain" ::
+  if Sys.os_type = "Win32" || Sys.getenv_opt "OCAML_SYSTEM" = Some "macosx"
+  then (
+    Printf.printf "Lin DSL Out_channel test with Domain disabled under Windows and macOS\n\n%!";
+    []
+  ) else [
     OC_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Out_channel test with Domain";
   ]
+
+let _ = QCheck_base_runner.run_tests_main tests


### PR DESCRIPTION
These tests are not triggering consistently on those platforms (and often take a lot of time) so this PR proposes to disable them at least for now, to reduce the noise of CI failures.
Maybe the frequencies could be tweaked so that they trigger most consistently? :thinking: