### PR TITLE
 Add agree_prop_par_asym to STM_domain

### DIFF
--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -8,6 +8,7 @@ module Make (Spec: Spec) = struct
     [@alert "-internal"]
 
   let check_obs = check_obs
+  let all_interleavings_ok = all_interleavings_ok
   let arb_cmds_triple = arb_cmds_triple
   let arb_triple = arb_triple
   let arb_triple_asym seq_len par_len arb0 arb1 arb2 =

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -69,7 +69,7 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
-         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 15 times when shrinking *)
+         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let neg_agree_test_par ~count ~name =
     let rep_count = 25 in
@@ -79,7 +79,7 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
-         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 15 times when shrinking *)
+         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let agree_test_par_asym ~count ~name =
     let rep_count = 25 in
@@ -89,7 +89,7 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
-         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 15 times when shrinking *)
+         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let neg_agree_test_par_asym ~count ~name =
     let rep_count = 25 in
@@ -99,5 +99,5 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
-         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 15 times when shrinking *)
+         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
 end

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -8,7 +8,8 @@ module Make (Spec: Spec) = struct
     [@alert "-internal"]
 
   let check_obs = check_obs
-  let all_interleavings_ok = all_interleavings_ok
+  let all_interleavings_ok (seq_pref,cmds1,cmds2) =
+    all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state
   let arb_cmds_triple = arb_cmds_triple
   let arb_triple = arb_triple
   let arb_triple_asym seq_len par_len arb0 arb1 arb2 =
@@ -67,8 +68,8 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (fun ((seq_pref,cmds1,cmds2) as triple) ->
-         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+      (fun triple ->
+         assume (all_interleavings_ok triple);
          repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let neg_agree_test_par ~count ~name =
@@ -77,8 +78,8 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make_neg ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (fun ((seq_pref,cmds1,cmds2) as triple) ->
-         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+      (fun triple ->
+         assume (all_interleavings_ok triple);
          repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let agree_test_par_asym ~count ~name =
@@ -87,8 +88,8 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (fun ((seq_pref,cmds1,cmds2) as triple) ->
-         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+      (fun triple ->
+         assume (all_interleavings_ok triple);
          repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
   let neg_agree_test_par_asym ~count ~name =
@@ -97,7 +98,7 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make_neg ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (fun ((seq_pref,cmds1,cmds2) as triple) ->
-         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+      (fun triple ->
+         assume (all_interleavings_ok triple);
          repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
 end

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -80,4 +80,24 @@ module Make (Spec: Spec) = struct
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
          repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 15 times when shrinking *)
-  end
+
+  let agree_test_par_asym ~count ~name =
+    let rep_count = 25 in
+    let seq_len,par_len = 20,12 in
+    let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
+    Test.make ~retries:10 ~max_gen ~count ~name
+      (arb_cmds_triple seq_len par_len)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 15 times when shrinking *)
+
+  let neg_agree_test_par_asym ~count ~name =
+    let rep_count = 25 in
+    let seq_len,par_len = 20,12 in
+    let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
+    Test.make_neg ~retries:10 ~max_gen ~count ~name
+      (arb_cmds_triple seq_len par_len)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 15 times when shrinking *)
+end

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -10,6 +10,9 @@ module Make (Spec: Spec) = struct
   let check_obs = check_obs
   let arb_cmds_triple = arb_cmds_triple
   let arb_triple = arb_triple
+  let arb_triple_asym seq_len par_len arb0 arb1 arb2 =
+    let arb_triple = arb_triple seq_len par_len arb0 arb1 arb2 in
+    set_print (print_triple_vertical ~center_prefix:false Spec.show_cmd) arb_triple
 
   (* operate over arrays to avoid needless allocation underway *)
   let interp_sut_res sut cs =

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -38,9 +38,6 @@ module Make (Spec: Spec) = struct
            (pref_obs,obs1,obs2)
 
   let agree_prop_par_asym (seq_pref, cmds1, cmds2) =
-  (*assume (WSDT_seq.cmds_ok WSDConf.init_state (seq_pref @ cmds1));
-    assume (WSDT_seq.cmds_ok WSDConf.init_state (seq_pref @ cmds2));*)
-    assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
     let sema = Semaphore.Binary.make false in
@@ -62,8 +59,6 @@ module Make (Spec: Spec) = struct
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35 ~center_prefix:false
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,parent_obs,child_obs)
-      (* @@ print_triple_vertical ~center_prefix:false show_res
-          (List.map snd pref_obs, List.map snd own_obs, List.map snd stealer_obs) *)
 
   let agree_test_par ~count ~name =
     let rep_count = 25 in

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -6,6 +6,11 @@ module Make : functor (Spec : STM.Spec) ->
     (** [check_obs pref cs1 cs2 s] tests whether the observations from the sequential prefix [pref]
         and the parallel traces [cs1] [cs2] agree with the model started in state [s]. *)
 
+    val all_interleavings_ok : Spec.cmd list -> Spec.cmd list -> Spec.cmd list -> Spec.state -> bool
+    (** [all_interleavings_ok seq spawn0 spawn1 state] checks that
+        preconditions of all the {!cmd}s of [seq], [spawn0], and [spawn1] are satisfied in all the
+        possible interleavings and starting with [state] *)
+
     val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
     (** [arb_cmds_triple seq_len par_len] generates a [cmd] triple with at most [seq_len]
         sequential commands and at most [par_len] parallel commands each.

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -22,7 +22,22 @@ module Make : functor (Spec : STM.Spec) ->
         and returns the list of corresponding {!Spec.cmd} and result pairs. *)
 
     val agree_prop_par : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
-    (** Parallel agreement property based on {!Stdlib.Domain} *)
+    (** Parallel agreement property based on {!Stdlib.Domain}.
+        [agree_prop_par (seq_pref, tl1, tl2)] first interprets [seq_pref]
+        and then spawns two parallel, symmetric domains interpreting [tl1] and
+        [tl2] simultaneously.
+
+        @return [true] if there exists a sequential interleaving of the results
+        which agrees with a model interpretation. *)
+
+    val agree_prop_par_asym : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
+    (** Asymmetric parallel agreement property based on {!Stdlib.Domain}.
+        [agree_prop_par_asym (seq_pref, tl1, tl2)] first interprets [seq_pref],
+        and then interprets [tl1] while a spawned domain interprets [tl2]
+        in parallel with the parent domain.
+
+        @return [true] if there exists a sequential interleaving of the results
+        which agrees with a model interpretation. *)
 
     val agree_test_par : count:int -> name:string -> QCheck.Test.t
     (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries] *)

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -6,10 +6,10 @@ module Make : functor (Spec : STM.Spec) ->
     (** [check_obs pref cs1 cs2 s] tests whether the observations from the sequential prefix [pref]
         and the parallel traces [cs1] [cs2] agree with the model started in state [s]. *)
 
-    val all_interleavings_ok : Spec.cmd list -> Spec.cmd list -> Spec.cmd list -> Spec.state -> bool
-    (** [all_interleavings_ok seq spawn0 spawn1 state] checks that
+    val all_interleavings_ok : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
+    (** [all_interleavings_ok (seq,spawn0,spawn1)] checks that
         preconditions of all the {!cmd}s of [seq], [spawn0], and [spawn1] are satisfied in all the
-        possible interleavings and starting with [state] *)
+        possible interleavings and starting with {!Spec.init_state}. *)
 
     val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
     (** [arb_cmds_triple seq_len par_len] generates a [cmd] triple with at most [seq_len]

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -51,18 +51,21 @@ module Make : functor (Spec : STM.Spec) ->
         which agrees with a model interpretation. *)
 
     val agree_test_par : count:int -> name:string -> QCheck.Test.t
-    (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries] *)
+    (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries].
+        Accepts two labeled parameters:
+        [count] is the number of test iterations and [name] is the printed test name. *)
 
     val neg_agree_test_par : count:int -> name:string -> QCheck.Test.t
     (** A negative parallel agreement test (for convenience). Accepts two labeled parameters:
-        [count] is the test count and [name] is the printed test name. *)
+        [count] is the number of test iterations and [name] is the printed test name. *)
 
     val agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
-    (** Asymmetric parallel agreement test based on {!Stdlib.Domain} and {!agree_prop_par_sym}
-        which combines [repeat] and [~retries] *)
+    (** Asymmetric parallel agreement test based on {!Stdlib.Domain} and {!agree_prop_par_asym}
+        which combines [repeat] and [~retries]. Accepts two labeled parameters:
+        [count] is the number of test iterations and [name] is the printed test name. *)
 
     val neg_agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
     (** A negative asymmetric parallel agreement test (for convenience).
         Accepts two labeled parameters:
-        [count] is the test count and [name] is the printed test name. *)
+        [count] is the number of test iterations and [name] is the printed test name. *)
  end

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -17,6 +17,12 @@ module Make : functor (Spec : STM.Spec) ->
         The three {!Spec.cmd} components are generated with [arb0], [arb1], and [arb2], respectively.
         Each of these take the model state as a parameter. *)
 
+    val arb_triple_asym : int -> int -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.state -> Spec.cmd QCheck.arbitrary) -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
+    (** [arb_triple_asym seq_len par_len arb0 arb1 arb2] creates a triple [cmd]
+        generator like {!arb_triple}. It differs in that the resulting printer
+        is asymmetric, printing [arb1]'s result below [arb0]'s result and
+        printing [arb2]'s result to the right of [arb1]'s result. *)
+
     val interp_sut_res : Spec.sut -> Spec.cmd list -> (Spec.cmd * STM.res) list
     (** [interp_sut_res sut cs] interprets the commands [cs] over the system {!Spec.sut}
         and returns the list of corresponding {!Spec.cmd} and result pairs. *)

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -54,7 +54,15 @@ module Make : functor (Spec : STM.Spec) ->
     (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries] *)
 
     val neg_agree_test_par : count:int -> name:string -> QCheck.Test.t
-    (** A negative agreement test (for convenience). Accepts two labeled parameters:
+    (** A negative parallel agreement test (for convenience). Accepts two labeled parameters:
         [count] is the test count and [name] is the printed test name. *)
 
+    val agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
+    (** Asymmetric parallel agreement test based on {!Stdlib.Domain} and {!agree_prop_par_sym}
+        which combines [repeat] and [~retries] *)
+
+    val neg_agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
+    (** A negative asymmetric parallel agreement test (for convenience).
+        Accepts two labeled parameters:
+        [count] is the test count and [name] is the printed test name. *)
  end

--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -10,12 +10,16 @@ let retries = 10
 let rt_int_neg_agree_test_par_asym ~count ~name =
   QCheck.Test.make_neg ~retries ~count ~name
     (RT_int.arb_triple_asym seq_len par_len RConf_int.arb_cmd RConf_int.arb_cmd RConf_int.arb_cmd)
-    (Util.repeat rep_count RT_int.agree_prop_par_asym)
+    (fun ((seq_pref,cmds1,cmds2) as triple) ->
+       QCheck.assume (RT_int.all_interleavings_ok seq_pref cmds1 cmds2 RConf_int.init_state);
+       Util.repeat rep_count RT_int.agree_prop_par_asym triple)
 
 let rt_int64_neg_agree_test_par_asym ~count ~name =
   QCheck.Test.make_neg ~retries ~count ~name
     (RT_int64.arb_triple_asym seq_len par_len RConf_int64.arb_cmd RConf_int64.arb_cmd RConf_int64.arb_cmd)
-    (Util.repeat rep_count RT_int64.agree_prop_par_asym)
+    (fun ((seq_pref,cmds1,cmds2) as triple) ->
+       QCheck.assume (RT_int64.all_interleavings_ok seq_pref cmds1 cmds2 RConf_int64.init_state);
+       Util.repeat rep_count RT_int64.agree_prop_par_asym triple)
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in

--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -2,9 +2,25 @@ open Stm_tests_spec_ref
 
 module RT_int   = STM_domain.Make(RConf_int)
 module RT_int64 = STM_domain.Make(RConf_int64)
+
+let rep_count = 25
+let seq_len,par_len = 20,12
+let retries = 10
+
+let rt_int_neg_agree_test_par_asym ~count ~name =
+  QCheck.Test.make_neg ~retries ~count ~name
+    (RT_int.arb_triple_asym seq_len par_len RConf_int.arb_cmd RConf_int.arb_cmd RConf_int.arb_cmd)
+    (Util.repeat rep_count RT_int.agree_prop_par_asym)
+
+let rt_int64_neg_agree_test_par_asym ~count ~name =
+  QCheck.Test.make_neg ~retries ~count ~name
+    (RT_int64.arb_triple_asym seq_len par_len RConf_int64.arb_cmd RConf_int64.arb_cmd RConf_int64.arb_cmd)
+    (Util.repeat rep_count RT_int64.agree_prop_par_asym)
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
    [RT_int.neg_agree_test_par      ~count ~name:"STM int ref test parallel";
     RT_int64.neg_agree_test_par    ~count ~name:"STM int64 ref test parallel";
+    rt_int_neg_agree_test_par_asym   ~count ~name:"STM int ref test parallel asymmetric";
+    rt_int64_neg_agree_test_par_asym ~count ~name:"STM int64 ref test parallel asymmetric";
    ])

--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -2,29 +2,11 @@ open Stm_tests_spec_ref
 
 module RT_int   = STM_domain.Make(RConf_int)
 module RT_int64 = STM_domain.Make(RConf_int64)
-
-let rep_count = 25
-let seq_len,par_len = 20,12
-let retries = 10
-
-let rt_int_neg_agree_test_par_asym ~count ~name =
-  QCheck.Test.make_neg ~retries ~count ~name
-    (RT_int.arb_triple_asym seq_len par_len RConf_int.arb_cmd RConf_int.arb_cmd RConf_int.arb_cmd)
-    (fun ((seq_pref,cmds1,cmds2) as triple) ->
-       QCheck.assume (RT_int.all_interleavings_ok seq_pref cmds1 cmds2 RConf_int.init_state);
-       Util.repeat rep_count RT_int.agree_prop_par_asym triple)
-
-let rt_int64_neg_agree_test_par_asym ~count ~name =
-  QCheck.Test.make_neg ~retries ~count ~name
-    (RT_int64.arb_triple_asym seq_len par_len RConf_int64.arb_cmd RConf_int64.arb_cmd RConf_int64.arb_cmd)
-    (fun ((seq_pref,cmds1,cmds2) as triple) ->
-       QCheck.assume (RT_int64.all_interleavings_ok seq_pref cmds1 cmds2 RConf_int64.init_state);
-       Util.repeat rep_count RT_int64.agree_prop_par_asym triple)
 ;;
 QCheck_runner.run_tests_main
   (let count = 1000 in
-   [RT_int.neg_agree_test_par      ~count ~name:"STM int ref test parallel";
-    RT_int64.neg_agree_test_par    ~count ~name:"STM int64 ref test parallel";
-    rt_int_neg_agree_test_par_asym   ~count ~name:"STM int ref test parallel asymmetric";
-    rt_int64_neg_agree_test_par_asym ~count ~name:"STM int64 ref test parallel asymmetric";
+   [RT_int.neg_agree_test_par        ~count ~name:"STM int ref test parallel";
+    RT_int64.neg_agree_test_par      ~count ~name:"STM int64 ref test parallel";
+    RT_int.neg_agree_test_par_asym   ~count ~name:"STM int ref test parallel asymmetric";
+    RT_int64.neg_agree_test_par_asym ~count ~name:"STM int64 ref test parallel asymmetric";
    ])


### PR DESCRIPTION
This PR fixes #310 by adding an asymmetric property `agree_prop_par_asym` to `STM_domain`.
This is handy to run tests that spawn only 1 child domain to run and interpret `cmd`s in parallel with the parent domain.
To make printing of such triples nicer, the PR includes a new triple generator `STM_domain.arb_triple_asym` that has a corresponding "symmetric printer" set.

I pinned the patched version locally to see how this would help clean up the existing `ws_deque` test from `lockfree`.
For comparison, here's a diff:
```diff
diff --git a/test/ws_deque/stm_ws_deque.ml b/test/ws_deque/stm_ws_deque.ml
index fd502bc..90af0d1 100644
--- a/test/ws_deque/stm_ws_deque.ml
+++ b/test/ws_deque/stm_ws_deque.ml
@@ -63,56 +63,22 @@ end
 module WSDT_seq = STM_sequential.Make (WSDConf)
 module WSDT_dom = STM_domain.Make (WSDConf)
 
-(* The following definitions differ slightly from those in multicoretests:lib/STM.ml.
-   This has to do with how work-stealing deques are supposed to be used according to spec:
-   - [agree_prop_par] differs in that it only spawns one domain ("a stealer domain")
-     in parallel with the original "owner domain" (it also uses [Semaphore.Binary]) *)
-let agree_prop_par (seq_pref, owner, stealer) =
-  assume (WSDT_seq.cmds_ok WSDConf.init_state (seq_pref @ owner));
-  assume (WSDT_seq.cmds_ok WSDConf.init_state (seq_pref @ stealer));
-  let sut = WSDConf.init_sut () in
-  let pref_obs = WSDT_dom.interp_sut_res sut seq_pref in
-  let sema = Semaphore.Binary.make false in
-  let stealer_dom =
-    Domain.spawn (fun () ->
-        Semaphore.Binary.release sema;
-        WSDT_dom.interp_sut_res sut stealer)
-  in
-  while not (Semaphore.Binary.try_acquire sema) do
-    Domain.cpu_relax ()
-  done;
-  let own_obs = WSDT_dom.interp_sut_res sut owner in
-  let stealer_obs = Domain.join stealer_dom in
-  let res =
-    WSDT_dom.check_obs pref_obs own_obs stealer_obs WSDConf.init_state
-  in
-  let () = WSDConf.cleanup sut in
-  res
-  || Test.fail_reportf "  Results incompatible with linearized model:\n\n%s"
-     @@ Util.print_triple_vertical ~center_prefix:false STM.show_res
-          (List.map snd pref_obs, List.map snd own_obs, List.map snd stealer_obs)
-
-(* [arb_cmds_par] differs in what each triple component generates:
-   "Owner domain" cmds can't be [Steal], "stealer domain" cmds can only be [Steal]. *)
-let arb_cmds_par =
-  WSDT_dom.arb_triple 20 15 WSDConf.arb_cmd WSDConf.arb_cmd WSDConf.stealer_cmd
-
 (* A parallel agreement test - w/repeat and retries combined *)
-let agree_test_par ~count ~name =
-  let rep_count = 50 in
-  Test.make ~retries:10 ~count ~name arb_cmds_par
-    (repeat rep_count agree_prop_par)
-
-(* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
-let agree_test_par_negative ~count ~name =
-  WSDT_dom.neg_agree_test_par ~count ~name
+let agree_test_par_asym ~count ~name =
+  let rep_count = 20 in
+  let seq_len,par_len = 20,12 in
+  Test.make ~retries:10 ~count ~name
+    (* "Owner domain" cmds can't be [Steal], "stealer domain" cmds can only be [Steal]. *)
+    (WSDT_dom.arb_triple_asym seq_len par_len WSDConf.arb_cmd WSDConf.arb_cmd WSDConf.stealer_cmd)
+    (repeat rep_count WSDT_dom.agree_prop_par_asym)
 
 let () =
   let count = 1000 in
   QCheck_base_runner.run_tests_main
     [
       WSDT_seq.agree_test ~count ~name:"STM Lockfree.Ws_deque test sequential";
-      agree_test_par ~count ~name:"STM Lockfree.Ws_deque test parallel";
-      agree_test_par_negative ~count
-        ~name:"STM Lockfree.Ws_deque test parallel, negative";
+      agree_test_par_asym ~count ~name:"STM Lockfree.Ws_deque test parallel";
+      (* Note: this can generate, e.g., pop commands/actions in different threads, thus violating the spec. *)
+      WSDT_dom.neg_agree_test_par
+                          ~count ~name:"STM Lockfree.Ws_deque test parallel, negative";
```

I realize that
- I left some commented out code which needs removing
- This needs a `Changes` entry