### PR TITLE
Avoid repetitive interleaving search in STM_domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next version
 
+- #318: avoid repetitive interleaving searches in `STM_domain` and `STM_thread`
 - ensure `cleanup` is run in the presence of exceptions in
   - `STM_sequential.agree_prop` and `STM_domain.agree_prop_par`
   - `Lin_thread.lin_prop` and `Lin_effect.lin_prop`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,10 @@
 ## Next version
 
 - #318: avoid repetitive interleaving searches in `STM_domain` and `STM_thread`
-- ensure `cleanup` is run in the presence of exceptions in
+- #312: Escape and quote `bytes` printed with `STM`'s `bytes` combinator
+- #295: ensure `cleanup` is run in the presence of exceptions in
   - `STM_sequential.agree_prop` and `STM_domain.agree_prop_par`
   - `Lin_thread.lin_prop` and `Lin_effect.lin_prop`
-- #312: Escape and quote `bytes` printed with `STM`'s `bytes` combinator
 
 ## 0.1.1
 

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -18,7 +18,6 @@ module Make (Spec: Spec) = struct
     List.combine cs (Array.to_list res_arr)
 
   let agree_prop_par (seq_pref,cmds1,cmds2) =
-    (*assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);*)
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
     let wait = Atomic.make true in

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -18,7 +18,7 @@ module Make (Spec: Spec) = struct
     List.combine cs (Array.to_list res_arr)
 
   let agree_prop_par (seq_pref,cmds1,cmds2) =
-    assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+    (*assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);*)
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
     let wait = Atomic.make true in
@@ -41,7 +41,9 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 15 times when shrinking *)
 
   let neg_agree_test_par ~count ~name =
     let rep_count = 25 in
@@ -49,5 +51,7 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make_neg ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (repeat rep_count agree_prop_par) (* 25 times each, then 25 * 15 times when shrinking *)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 15 times when shrinking *)
   end

--- a/lib/STM_thread.ml
+++ b/lib/STM_thread.ml
@@ -21,7 +21,6 @@ module Make (Spec: Spec) = struct
 
   (* Concurrent agreement property based on [Threads] *)
   let agree_prop_conc (seq_pref,cmds1,cmds2) =
-    (*assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);*)
     let sut = Spec.init_sut () in
     let obs1,obs2 = ref (Error ThreadNotFinished), ref (Error ThreadNotFinished) in
     let pref_obs = interp_sut_res sut seq_pref in

--- a/lib/STM_thread.ml
+++ b/lib/STM_thread.ml
@@ -21,7 +21,7 @@ module Make (Spec: Spec) = struct
 
   (* Concurrent agreement property based on [Threads] *)
   let agree_prop_conc (seq_pref,cmds1,cmds2) =
-    assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+    (*assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);*)
     let sut = Spec.init_sut () in
     let obs1,obs2 = ref (Error ThreadNotFinished), ref (Error ThreadNotFinished) in
     let pref_obs = interp_sut_res sut seq_pref in
@@ -46,7 +46,9 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make ~retries:15 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (repeat rep_count agree_prop_conc) (* 100 times each, then 100 * 15 times when shrinking *)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_conc triple) (* 100 times each, then 100 * 15 times when shrinking *)
 
   let neg_agree_test_conc ~count ~name =
     let rep_count = 25 in
@@ -54,5 +56,7 @@ module Make (Spec: Spec) = struct
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
     Test.make_neg ~retries:15 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
-      (repeat rep_count agree_prop_conc) (* 25 times each, then 25 * 15 times when shrinking *)
+      (fun ((seq_pref,cmds1,cmds2) as triple) ->
+         assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
+         repeat rep_count agree_prop_conc triple) (* 100 times each, then 100 * 15 times when shrinking *)
   end


### PR DESCRIPTION
In STM_domain we use `assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state)` to ensure that all `cmd` preconditions in a triple are satisfied under all interleavings.
I realize we are checking the precondition repeatedly - once for each `Util.repeat` iteration! :scream: 
By default, that means we are exploring that same exponential space 25 times whereas 1 one would do.
The PR proposes to move the precondition check outside `agree_prop_par` and the `Util.repeat` loop for both `STM_domain` and `STM_thread`.

Overall I was expecting grand CI speed-ups from this - and I encountered a few of those, e.g., `Linux trunk` in 22m31s!
Many runs however didn't speed up because of long running IO tests... I'm hoping that this together with frequency adjusted or disabled IO tests (#314) will collectively provide a solid boost in CI testing time :crossed_fingers: 