### PR TITLE
Out_channel frequency adjustment

### DIFF
--- a/src/io/lin_tests_dsl_common.ml
+++ b/src/io/lin_tests_dsl_common.ml
@@ -67,8 +67,8 @@ module OCConf : Lin.Spec = struct
     (* val_ "Out_channel.with_open_gen"    Out_channel.with_open_gen    (open_flag list @-> int @-> string @-> (t @-> 'a) @-> returning 'a) ; *)
 
     val_ "Out_channel.seek"             (lift Out_channel.seek)             (t @-> int64 @-> returning_or_exc unit) ;
-    val_freq 2 "Out_channel.pos"        (lift Out_channel.pos)              (t @-> returning_or_exc int64) ;
-    val_freq 2 "Out_channel.length"     (lift Out_channel.length)           (t @-> returning_or_exc int64) ;
+    val_freq 3 "Out_channel.pos"        (lift Out_channel.pos)              (t @-> returning_or_exc int64) ;
+    val_freq 3 "Out_channel.length"     (lift Out_channel.length)           (t @-> returning_or_exc int64) ;
     val_ "Out_channel.close"            (lift Out_channel.close)            (t @-> returning_or_exc unit) ;
     val_ "Out_channel.close_noerr"      (lift Out_channel.close_noerr)      (t @-> returning unit) ;
     val_ "Out_channel.flush"            (lift Out_channel.flush)            (t @-> returning_or_exc unit) ;

--- a/src/io/lin_tests_dsl_common.ml
+++ b/src/io/lin_tests_dsl_common.ml
@@ -67,8 +67,8 @@ module OCConf : Lin.Spec = struct
     (* val_ "Out_channel.with_open_gen"    Out_channel.with_open_gen    (open_flag list @-> int @-> string @-> (t @-> 'a) @-> returning 'a) ; *)
 
     val_ "Out_channel.seek"             (lift Out_channel.seek)             (t @-> int64 @-> returning_or_exc unit) ;
-    val_ "Out_channel.pos"              (lift Out_channel.pos)              (t @-> returning_or_exc int64) ;
-    val_ "Out_channel.length"           (lift Out_channel.length)           (t @-> returning_or_exc int64) ;
+    val_freq 2 "Out_channel.pos"        (lift Out_channel.pos)              (t @-> returning_or_exc int64) ;
+    val_freq 2 "Out_channel.length"     (lift Out_channel.length)           (t @-> returning_or_exc int64) ;
     val_ "Out_channel.close"            (lift Out_channel.close)            (t @-> returning_or_exc unit) ;
     val_ "Out_channel.close_noerr"      (lift Out_channel.close_noerr)      (t @-> returning unit) ;
     val_ "Out_channel.flush"            (lift Out_channel.flush)            (t @-> returning_or_exc unit) ;


### PR DESCRIPTION
I was looking at the `Out_channel` tests and noticed something: most of the tested operations are returning `unit` (in contrast to `In_channel` where most of them return observable values).
This decreases the chance of observing sequential consistency failures about the tested `Out_channel.t`.

This PR therefore increases the frequency of non-unit-returning functions, `pos` and `length` in `Out_channel`.
It works reasonably well: focused tests repeated 10 times triggers the expected failures on Windows and macOS as expected within the first 100-200 generated test input. We should consider this as an alternative to #314.

(Note: CI is failing on `trunk` while compiling `ppxlib` due to an AST-changing PR earlier today. The Windows `trunk` version is however based on another branch which hasn't been updated yet AFAICS)