### PR TITLE
Fixes small issues in CI

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -281,14 +281,14 @@ jobs:
       - name: Install Multicore Tests dependencies
         run: |
           opam install . --deps-only --with-test
-          opam clean --all-switches --unused-repositories --logs --download-cache --repo-cache
 
-      - name: Show configuration
+      - name: Show configuration and clean up
         run: |
           opam exec -- ocamlc -config
           opam config list
           opam exec -- dune printenv
           opam list --columns=name,installed-version,repository,synopsis-or-target
+          opam clean --all-switches --unused-repositories --logs --download-cache --repo-cache
 
       - name: Save OPAM state (Cygwin)
         uses: actions/cache/save@v3

--- a/.github/workflows/windows-510-trunk-bytecode-workflow.yml
+++ b/.github/workflows/windows-510-trunk-bytecode-workflow.yml
@@ -8,4 +8,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.1.0,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler_git_ref: refs/heads/trunk
       timeout: 360


### PR DESCRIPTION
Runs with `ppxlib` no longer building with `trunk` revealed two issues that were unnoticed in the Windows workflows