### PR TITLE
Add Lin tests for Base.Buffer

### DIFF
--- a/src/base/buffer/BaseOrNoBase.fallback.ml
+++ b/src/base/buffer/BaseOrNoBase.fallback.ml
@@ -1,0 +1,3 @@
+module Buffer = Stdlib.Buffer
+
+let _ = failwith "This is using a placeholder for compilation, do not run!"

--- a/src/base/buffer/BaseOrNoBase.passthrough.ml
+++ b/src/base/buffer/BaseOrNoBase.passthrough.ml
@@ -1,0 +1,1 @@
+module Buffer = Base.Buffer

--- a/src/base/buffer/dune
+++ b/src/base/buffer/dune
@@ -1,0 +1,12 @@
+(executable
+ (name lin_tests_dsl)
+ (libraries qcheck-lin.domain
+  (select BaseOrNoBase.ml from
+   (base -> BaseOrNoBase.passthrough.ml)
+   (-> BaseOrNoBase.fallback.ml))))
+
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (enabled_if %{lib-available:base})
+ (action (run %{dep:lin_tests_dsl.exe} --verbose)))

--- a/src/base/buffer/lin_tests_dsl.ml
+++ b/src/base/buffer/lin_tests_dsl.ml
@@ -18,7 +18,7 @@ module BBConf = struct
       (* val_ "Buffer.create" Buffer.create (int @-> returning t); *)
           (* Disabled as returning t *)
 
-      val_ "Buffer.contents" Buffer.contents (t @-> returning string);
+      val_ "Buffer.contents" Buffer.contents (t @-> returning_or_exc string);
 
       (* val_ "Buffer.contents_bytes" Buffer.contents_bytes (t @-> returning bytes); *)
           (* Disabled due to missing bytes *)
@@ -27,8 +27,8 @@ module BBConf = struct
       val_ "Buffer.length" Buffer.length (t @-> returning int);
       val_ "Buffer.clear" Buffer.clear (t @-> returning unit);
       val_ "Buffer.reset" Buffer.reset (t @-> returning unit);
-      val_ "Buffer.add_char" Buffer.add_char (t @-> char @-> returning unit);
-      val_ "Buffer.add_string" Buffer.add_string (t @-> string @-> returning unit);
+      val_ "Buffer.add_char" Buffer.add_char (t @-> char @-> returning_or_exc unit);
+      val_ "Buffer.add_string" Buffer.add_string (t @-> string @-> returning_or_exc unit);
 
       (* val_ "Buffer.add_substring" Buffer.add_substring (t @-> string @-> int @-> int @-> returning_or_exc unit); *)
           (* Disabled due to missing labels *)

--- a/src/base/buffer/lin_tests_dsl.ml
+++ b/src/base/buffer/lin_tests_dsl.ml
@@ -1,0 +1,48 @@
+module Buffer = BaseOrNoBase.Buffer
+
+module BBConf = struct
+  type t = Buffer.t
+
+  let init () = Buffer.create 8
+  let cleanup _ = ()
+
+  open Lin
+  let int = nat_small
+  let char = char_printable
+  let string = string_small_printable
+
+  let api =
+    [
+      (* val_ "Buffer.sexp_of_t" Buffer.sexp_of_t (t @-> returning Sexplib0.Sexp.t); *)
+          (* Disabled due to missing Sexplib0.Sexp.t *)
+      (* val_ "Buffer.create" Buffer.create (int @-> returning t); *)
+          (* Disabled as returning t *)
+
+      val_ "Buffer.contents" Buffer.contents (t @-> returning string);
+
+      (* val_ "Buffer.contents_bytes" Buffer.contents_bytes (t @-> returning bytes); *)
+          (* Disabled due to missing bytes *)
+
+      val_ "Buffer.nth" Buffer.nth (t @-> int @-> returning_or_exc char);
+      val_ "Buffer.length" Buffer.length (t @-> returning int);
+      val_ "Buffer.clear" Buffer.clear (t @-> returning unit);
+      val_ "Buffer.reset" Buffer.reset (t @-> returning unit);
+      val_ "Buffer.add_char" Buffer.add_char (t @-> char @-> returning unit);
+      val_ "Buffer.add_string" Buffer.add_string (t @-> string @-> returning unit);
+
+      (* val_ "Buffer.add_substring" Buffer.add_substring (t @-> string @-> int @-> int @-> returning_or_exc unit); *)
+          (* Disabled due to missing labels *)
+
+      (* val_ "Buffer.add_bytes" Buffer.add_bytes (t @-> bytes @-> returning unit); *)
+      (* val_ "Buffer.add_subbytes" Buffer.add_subbytes (t @-> bytes @-> int @-> int @-> returning unit); *)
+          (* Disabled due to missing bytes *)
+
+      (* val_ "Buffer.add_buffer" Buffer.add_buffer (t @-> t @-> unit); *)
+    ]
+end
+
+module BBT_domain = Lin_domain.Make(BBConf)
+
+let _ =
+  QCheck_base_runner.run_tests_main
+    [ BBT_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Base Buffer test with Domain" ]


### PR DESCRIPTION
Add Lin tests for Base.Buffer. This is split into two commits to keep track of the functions that can raise exceptions when used in parallel (while they shouldn’t in a sequential use).

Segfaults happened on 5.0.0 in CI, for instance [there](https://github.com/shym/multicoretests/actions/runs/4619228913/jobs/8167695430#step:20:799):
```
random seed: 255066454
generated error fail pass / total     time test name

[ ]    0    0    0    0 / 1000     0.0s Lin DSL Base Buffer test with Domain
/home/runner/work/_temp/cfbbcd46-3b2b-4f6b-b063-35a9068fc155.sh: line 2: 3690717 Segmentation fault      (core dumped) opam exec -- dune exec "$ONLY_TEST" -- -v
[ ]    0    0    0    0 / 1000     0.0s Lin DSL Base Buffer test with Domain (generating)
```
This is hopefully another symptom of ocaml/ocaml#12103 which was fixed on `trunk` by ocaml/ocaml#12104.