### PR TITLE
Follow the update of trunk to 5.2

### DIFF
--- a/.github/workflows/cygwin-520-trunk-workflow.yml
+++ b/.github/workflows/cygwin-520-trunk-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml.5.1.0
+      compiler: ocaml.5.2.0
       cygwin: true
       compiler_git_ref: refs/heads/trunk
       timeout: 360
@@ -19,7 +19,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml.5.1.0
+      compiler: ocaml.5.2.0
       cygwin: true
       compiler_git_ref: refs/heads/trunk
       timeout: 360

--- a/.github/workflows/linux-520-32bit-trunk-workflow.yml
+++ b/.github/workflows/linux-520-32bit-trunk-workflow.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0+trunk,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.2.0+trunk,ocaml-option-32bit'
       compiler_git_ref: refs/heads/trunk
       timeout: 360
       override_apt_install: bubblewrap gcc-multilib g++-multilib libzstd1:i386 libzstd-dev:i386

--- a/.github/workflows/linux-520-bytecode-trunk-workflow.yml
+++ b/.github/workflows/linux-520-bytecode-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: Bytecode trunk
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,5 +6,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0+trunk'
+      compiler: 'ocaml-variants.5.2.0+trunk,ocaml-option-bytecode-only'
       compiler_git_ref: refs/heads/trunk
+      timeout: 360

--- a/.github/workflows/linux-520-debug-trunk-workflow.yml
+++ b/.github/workflows/linux-520-debug-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Windows trunk
+name: Linux trunk debug
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,7 +6,8 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      runs_on: windows-latest
-      compiler: ocaml.5.1.0,ocaml-option-mingw
+      compiler: 'ocaml-variants.5.2.0+trunk'
       compiler_git_ref: refs/heads/trunk
+      dune_profile: 'debug-runtime'
+      runparam: 'v=0,V=1'
       timeout: 360

--- a/.github/workflows/linux-520-trunk-workflow.yml
+++ b/.github/workflows/linux-520-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Bytecode trunk
+name: Linux trunk
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,6 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0+trunk,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.2.0+trunk'
       compiler_git_ref: refs/heads/trunk
-      timeout: 360

--- a/.github/workflows/macosx-520-trunk-workflow.yml
+++ b/.github/workflows/macosx-520-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: Win bytecode trunk
+name: macOS trunk
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,7 +6,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      runs_on: windows-latest
-      compiler: ocaml.5.1.0,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: 'ocaml-variants.5.2.0+trunk'
       compiler_git_ref: refs/heads/trunk
-      timeout: 360
+      runs_on: 'macos-latest'

--- a/.github/workflows/windows-520-trunk-bytecode-workflow.yml
+++ b/.github/workflows/windows-520-trunk-bytecode-workflow.yml
@@ -1,4 +1,4 @@
-name: Linux trunk debug
+name: Win bytecode trunk
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,8 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0+trunk'
+      runs_on: windows-latest
+      compiler: ocaml.5.2.0,ocaml-option-mingw,ocaml-option-bytecode-only
       compiler_git_ref: refs/heads/trunk
-      dune_profile: 'debug-runtime'
-      runparam: 'v=0,V=1'
       timeout: 360

--- a/.github/workflows/windows-520-trunk-workflow.yml
+++ b/.github/workflows/windows-520-trunk-workflow.yml
@@ -1,4 +1,4 @@
-name: macOS trunk
+name: Windows trunk
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -6,6 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0+trunk'
+      runs_on: windows-latest
+      compiler: ocaml.5.2.0,ocaml-option-mingw
       compiler_git_ref: refs/heads/trunk
-      runs_on: 'macos-latest'
+      timeout: 360

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Multicore tests
 [![Windows 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-500-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-500-workflow.yml)
 [![Windows 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-500-bytecode-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-500-bytecode-workflow.yml)
 
-[![Linux 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-trunk-workflow.yml)
-[![MacOSX 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-510-trunk-workflow.yml)
-[![Linux 5.1.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-bytecode-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-bytecode-trunk-workflow.yml)
-[![Linux 5.1.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-debug-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-debug-trunk-workflow.yml)
-[![Linux 32-bit 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-32bit-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-32bit-trunk-workflow.yml)
-[![Windows 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml)
-[![Windows 5.1.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml)
-[![Cygwin 5.1.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-510-trunk-workflow.yml)
+[![Linux 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-trunk-workflow.yml)
+[![MacOSX 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-520-trunk-workflow.yml)
+[![Linux 5.2.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-bytecode-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode-trunk-workflow.yml)
+[![Linux 5.2.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-debug-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug-trunk-workflow.yml)
+[![Linux 32-bit 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-510-32bit-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit-trunk-workflow.yml)
+[![Windows 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-520-trunk-workflow.yml)
+[![Windows 5.2.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-510-trunk-bytecode-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/windows-520-trunk-bytecode-workflow.yml)
+[![Cygwin 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-510-trunk-workflow.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520-trunk-workflow.yml)
 
 Property-based tests of (parts of) the OCaml multicore compiler and run time.
 


### PR DESCRIPTION
Update all the CI jobs for `trunk` so that they build OCaml 5.2, following the branching of 5.1 earlier this week.