### PR TITLE
Chore: src/neg_tests cleanups

### DIFF
--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -53,14 +53,14 @@
  (name lin_tests_dsl_common)
  (modules lin_tests_dsl_common)
  (package multicoretests)
- (libraries CList qcheck-lin.domain)
+ (libraries CList qcheck-lin.lin)
 )
 
 (library
  (name lin_tests_common)
  (modules lin_tests_common)
  (package multicoretests)
- (libraries CList qcheck-lin.domain)
+ (libraries CList qcheck-lin.lin)
  (preprocess (pps ppx_deriving_qcheck ppx_deriving.show ppx_deriving.eq))
 )
 
@@ -69,7 +69,7 @@
  (modules lin_tests_dsl_domain)
  (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_dsl_common)
+ (libraries lin_tests_dsl_common qcheck-lin.domain)
  (action (run %{test} --verbose))
 )
 
@@ -99,7 +99,7 @@
  (modules lin_tests_domain)
  (package multicoretests)
  (flags (:standard -w -27))
- (libraries lin_tests_common)
+ (libraries lin_tests_common qcheck-lin.domain)
   ; (action (run %{test} --verbose))
  (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
 )

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -4,7 +4,7 @@
  (name stm_tests_spec_ref)
  (modules stm_tests_spec_ref)
  (package multicoretests)
- (libraries qcheck qcheck-stm.stm)
+ (libraries qcheck-core qcheck-stm.stm)
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
 )
 

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -88,9 +88,6 @@ module RConf_int64 = struct
   let cleanup _ = ()
 end
 
-module RT_int_domain = Lin_domain.Make_internal(RConf_int) [@alert "-internal"]
-module RT_int64_domain = Lin_domain.Make_internal(RConf_int64) [@alert "-internal"]
-
 
 (** ********************************************************************** *)
 (**                  Tests of the buggy concurrent list CList              *)
@@ -139,5 +136,3 @@ module Int64 = struct
   include Stdlib.Int64
   let shrink = Shrink.int64
 end
-module CLT_int_domain = Lin_domain.Make_internal(CLConf (Int)) [@alert "-internal"]
-module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64)) [@alert "-internal"]

--- a/src/neg_tests/lin_tests_domain.ml
+++ b/src/neg_tests/lin_tests_domain.ml
@@ -1,5 +1,10 @@
 open Lin_tests_common
 
+module RT_int_domain = Lin_domain.Make_internal(RConf_int) [@alert "-internal"]
+module RT_int64_domain = Lin_domain.Make_internal(RConf_int64) [@alert "-internal"]
+module CLT_int_domain = Lin_domain.Make_internal(CLConf (Int)) [@alert "-internal"]
+module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64)) [@alert "-internal"]
+
 (** This is a driver of the negative tests over the Domain module *)
 
 ;;

--- a/src/neg_tests/lin_tests_dsl_common.ml
+++ b/src/neg_tests/lin_tests_dsl_common.ml
@@ -52,9 +52,6 @@ module Ref_int64_spec : Spec = struct
     ]
   end
 
-module RT_int_domain = Lin_domain.Make(Ref_int_spec)
-module RT_int64_domain = Lin_domain.Make(Ref_int64_spec)
-
 (** ********************************************************************** *)
 (**                  Tests of the buggy concurrent list CList              *)
 (** ********************************************************************** *)
@@ -82,6 +79,3 @@ struct
       val_ "CList.member"   CList.member  (t @-> int64 @-> returning bool);
     ]
   end
-
-module CLT_int_domain = Lin_domain.Make(CList_spec_int)
-module CLT_int64_domain = Lin_domain.Make(CList_spec_int64)

--- a/src/neg_tests/lin_tests_dsl_domain.ml
+++ b/src/neg_tests/lin_tests_dsl_domain.ml
@@ -1,5 +1,10 @@
 open Lin_tests_dsl_common
 
+module RT_int_domain = Lin_domain.Make(Ref_int_spec)
+module RT_int64_domain = Lin_domain.Make(Ref_int64_spec)
+module CLT_int_domain = Lin_domain.Make(CList_spec_int)
+module CLT_int64_domain = Lin_domain.Make(CList_spec_int64)
+
 (** This is a driver of the negative tests over the Domain module *)
 
 ;;

--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -3,7 +3,7 @@ open Stm_tests_spec_ref
 module RT_int   = STM_domain.Make(RConf_int)
 module RT_int64 = STM_domain.Make(RConf_int64)
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int.neg_agree_test_par        ~count ~name:"STM int ref test parallel";
     RT_int64.neg_agree_test_par      ~count ~name:"STM int64 ref test parallel";

--- a/src/neg_tests/stm_tests_sequential_ref.ml
+++ b/src/neg_tests/stm_tests_sequential_ref.ml
@@ -3,7 +3,7 @@ open Stm_tests_spec_ref
 module RT_int_seq   = STM_sequential.Make(RConf_int)
 module RT_int64_seq = STM_sequential.Make(RConf_int64)
 ;;
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [RT_int_seq.agree_test   ~count ~name:"STM int ref test sequential";
     RT_int64_seq.agree_test ~count ~name:"STM int64 ref test sequential";

--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -7,7 +7,7 @@ if Sys.backend_type = Sys.Bytecode
 then
   Printf.printf "STM ref tests with Thread disabled under bytecode\n\n%!"
 else
-QCheck_runner.run_tests_main
+QCheck_base_runner.run_tests_main
   [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
    RT_int64.neg_agree_test_conc ~count:1000 ~name:"STM int64 ref test with Thread";
   ]


### PR DESCRIPTION
While trying out #329 on selected parts of the test suite locally I discovered a couple of needless dependencies in src/neg_tests. This PR seeks to remove them:

- Our  `src/neg_tests/lin` `Thread` tests depended on `lin_common*` files both needlessly requiring `Domain`s - and so we move the `Lin_domain` functor applications to the `Domain`-driver files
- The `src/neg_tests/stm_tests*` had a `qcheck` dependency rather than requiring `qcheck-core` and so we switch to using `QCheck_base_runner` like the rest of the test suite.
