### PR TITLE
Adjust asym test counts

### DIFF
--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -4,9 +4,8 @@ module RT_int   = STM_domain.Make(RConf_int)
 module RT_int64 = STM_domain.Make(RConf_int64)
 ;;
 QCheck_base_runner.run_tests_main
-  (let count = 1000 in
-   [RT_int.neg_agree_test_par        ~count ~name:"STM int ref test parallel";
-    RT_int64.neg_agree_test_par      ~count ~name:"STM int64 ref test parallel";
-    RT_int.neg_agree_test_par_asym   ~count ~name:"STM int ref test parallel asymmetric";
-    RT_int64.neg_agree_test_par_asym ~count ~name:"STM int64 ref test parallel asymmetric";
-   ])
+  [RT_int.neg_agree_test_par        ~count:1000 ~name:"STM int ref test parallel";
+   RT_int64.neg_agree_test_par      ~count:1000 ~name:"STM int64 ref test parallel";
+   RT_int.neg_agree_test_par_asym   ~count:2000 ~name:"STM int ref test parallel asymmetric";
+   RT_int64.neg_agree_test_par_asym ~count:2000 ~name:"STM int64 ref test parallel asymmetric";
+  ]


### PR DESCRIPTION
This little PR adjusts the test counts for the two recently added asym tests in `src/neg_tests` in an attempt to trigger them more consistently after having observed 2 failures to trigger them under Cygwin in the CI runs of #330.

Since this is for negative tests, on all other platforms the increased test count  should have no impact because a counter example will be found before getting to high counts.