### PR TITLE
CI: Catch apt-get --yes install just as apt-get install

### DIFF
--- a/.github/bin/sudo
+++ b/.github/bin/sudo
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Dummy `sudo`, to skip some useless installations
-if [ "$1" = "apt-get" -a "$2" = "install" ]; then
+if [ "$1" = "apt-get" -a "(" "$2" = "install" -o "(" "$2" = "--yes" -a "$3" = "install" ")" ")" ]; then
   if [ -n "$OVERRIDE_APT_INSTALL" ]; then
     echo "Dummy sudo: installing only $OVERRIDE_APT_INSTALL instead of running: $@"
     exec /usr/bin/sudo apt-get install $OVERRIDE_APT_INSTALL


### PR DESCRIPTION
Following ocaml/setup-ocaml#658, the invocation of apt-get changed, which broke linux CI