### PR TITLE
A few 4.14 updates

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -15,6 +15,13 @@ jobs:
     env:
       QCHECK_MSG_INTERVAL:      '60'
 
+    strategy:
+      matrix:
+        ocaml-compiler:
+          - 4.14.x
+          - 5.0.0
+          - ocaml-variants.5.1.0+trunk
+
     runs-on: ubuntu-latest
 
     steps:
@@ -24,7 +31,7 @@ jobs:
       - name: Install OCaml compiler
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: 5.0.0
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-depext: false
 
       - name: Test installation of the OPAM packages

--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ Sequential `STM` tests targeting `Sys.rename` found [two corner cases
 where MingW behaves differently](https://github.com/ocaml/ocaml/issues/12073)
 
 
-`flexdll` contains a race condition in its handling of errors (new, flexdll)
-----------------------------------------------------------------------------
+`flexdll` contains a race condition in its handling of errors (new, fixed, flexdll)
+-----------------------------------------------------------------------------------
 
 Parallel `Lin` tests of the `Dynlink` module found [a race
 condition](https://github.com/ocaml/flexdll/pull/112) in accesses to

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ helpful](https://tarides.com/blog/2022-12-22-ocaml-5-multicore-testing-tools).
 Installation instructions, and running the tests
 ================================================
 
-Both the libraries and the test suite require OCaml 5.0:
+The multicore test suite requires OCaml 5.0 (or newer):
 ```
 opam update
 opam switch create 5.0.0
 ```
 
 The two testing libraries are available as packages `qcheck-lin`
-and `qcheck-stm` from the opam repository and can be installed in
-the usual way:
+and `qcheck-stm` from the opam repository. The full versions require
+OCaml 5.x and reduced, non-`Domain` versions are available for OCaml
+4.14.x. They can be installed in the usual way:
 ```
 opam install qcheck-lin
 opam install qcheck-stm


### PR DESCRIPTION
In relation to #329 this PR
- updates the CI installation job to also check 4.14 (and 5.1) opam package installation
- documents the 4.14 availability in the README

To avoid triggering a entire separate CI-run for it, I include an update to set the found Flexdll issue to 'fixed'.