### PR TITLE
OCaml 4.13 compatibility

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         ocaml-compiler:
+          - 4.13.x
           - 4.14.x
           - 5.0.0
           - ocaml-variants.5.1.0+trunk

--- a/dune-project
+++ b/dune-project
@@ -47,7 +47,7 @@ and explained by some sequential interleaving.")
  (tags ("test" "property" "qcheck" "quickcheck" "parallelism" "sequential consistency"))
  (depopts base-domains)
  (depends
-  (ocaml (>= 4.14))
+  (ocaml (>= 4.13))
   (qcheck-core           (>= "0.20"))
   (qcheck-multicoretests-util (= :version))
   (ppx_deriving          (and :with-test (>= "5.2.1")))))

--- a/qcheck-lin.opam
+++ b/qcheck-lin.opam
@@ -22,7 +22,7 @@ homepage: "https://github.com/ocaml-multicore/multicoretests"
 bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
-  "ocaml" {>= "4.14"}
+  "ocaml" {>= "4.13"}
   "qcheck-core" {>= "0.20"}
   "qcheck-multicoretests-util" {= version}
   "ppx_deriving" {with-test & >= "5.2.1"}


### PR DESCRIPTION
This is the change mentioned in https://github.com/ocaml-multicore/multicoretests/pull/329#issuecomment-1513515412

I've added a workflow to make sure the compatibility doesn't get broken, let me know if this is inconvenient for you.

I've opened the PR rather than waiting for edwin to come back because with the current situation, the patch is needed in order to make CI pass for https://github.com/xapi-project/xen-api/pull/4985 so I'd rather get the compatibility merged sooner rather than later