### PR TITLE
Opam installation updates

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -4,11 +4,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on:
-  schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-and-test:

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -162,6 +162,11 @@ module Equal = struct
   let equal_option = Option.equal
   let equal_result eq_o eq_e x y = Result.equal ~ok:eq_o ~error:eq_e x y
   let equal_list = List.equal
-  let equal_seq = Seq.equal
+  let rec equal_seq eq s1 s2 = (* To support OCaml 4.13 as Seq.equal was added in 4.14 *)
+    let open Seq in
+    match s1 (), s2 () with
+    | Nil, Nil -> true
+    | Cons (a, an), Cons (b, bn) when eq a b -> equal_seq eq an bn
+    | _ -> false
   let equal_array eq x y = Seq.equal eq (Array.to_seq x) (Array.to_seq y)
 end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -168,5 +168,5 @@ module Equal = struct
     | Nil, Nil -> true
     | Cons (a, an), Cons (b, bn) when eq a b -> equal_seq eq an bn
     | _ -> false
-  let equal_array eq x y = Seq.equal eq (Array.to_seq x) (Array.to_seq y)
+  let equal_array eq x y = equal_seq eq (Array.to_seq x) (Array.to_seq y)
 end


### PR DESCRIPTION
This fixes #345 

When checking to see whether the ppx avoiding in #342 would fix the failing `opam install` from #345, I discovered that the #342's refactoring actually broke the 4.13 support just added in #340...

This PR thus 
- writes out the `Seq.equal` definition contributed in #340 
- updates the `opam install` workflow to run on all changes

The install workflows are quite fast, so I favor protecting against such breakage again now that we actually support 4.13 and 4.14.