### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -123,7 +123,7 @@ jobs:
         if: "runner.os == 'Windows' && inputs.cygwin"
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Pre-setup ($PATH, cache prefix, custom OPAM package for the compiler)
         id: presetup

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache opam
         id: cache-opam
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.opam
           key: opam-ubuntu-latest-5.0.0

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install OCaml compiler
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
This PR bumps the used version of `actions/checkout` to v3, which apparently may improve Windows CI times a bit: https://github.com/actions/checkout/releases/tag/v3.5.1