### PR TITLE
CI: Skip Cygwin part 2 when running only one test

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -80,9 +80,13 @@ on:
           Defaults to custom_compiler_version chunked at [+~-]
         type: string
         default: ''
+    outputs:
+      skippart2:
+        description: 'Whether Part 2 (Cygwin workflow) should be skipped (because we are running only one test)'
+        value: ${{ jobs.test.outputs.skippart2 }}
 
 jobs:
-  build-and-test:
+  test:
     env:
       QCHECK_MSG_INTERVAL:      '60'
       DUNE_PROFILE:             ${{ inputs.dune_profile }}
@@ -107,6 +111,9 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
 
     timeout-minutes: ${{ inputs.timeout }}
+
+    outputs:
+      skippart2: ${{ steps.winonlyone.outputs.skippart2 }}
 
     steps:
       - name: Configure environment (Cygwin)
@@ -334,7 +341,9 @@ jobs:
         if: env.ONLY_TEST != '' && runner.os != 'Windows'
 
       - name: Run only one test (Windows)
+        id: winonlyone
         run: |
+          echo "skippart2=true" >> "${env:GITHUB_OUTPUT}"
           if("${env:REPEATS_FAILFAST}" -eq "false") {
             $ErrorActionPreference = 'Continue'
           }

--- a/.github/workflows/cygwin-510.yml
+++ b/.github/workflows/cygwin-510.yml
@@ -14,7 +14,7 @@ jobs:
 
   part2:
     needs: part1
-    if: ${{ always() }}
+    if: ${{ always() && needs.part1.outputs.skippart2 != 'true' }}
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest

--- a/.github/workflows/cygwin-520-trunk.yml
+++ b/.github/workflows/cygwin-520-trunk.yml
@@ -15,7 +15,7 @@ jobs:
 
   part2:
     needs: part1
-    if: ${{ always() }}
+    if: ${{ always() && needs.part1.outputs.skippart2 != 'true' }}
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest


### PR DESCRIPTION
The title says it all.
Log of a successful run, where the second part is skipped as intended: https://github.com/shym/multicoretests/actions/runs/5175500758

Closes #350