### PR TITLE
Don't consider Sys STM tests negative on ARM64

### DIFF
--- a/src/sys/stm_tests.ml
+++ b/src/sys/stm_tests.ml
@@ -314,11 +314,15 @@ struct
     | _,_ -> false
 end
 
-let uname_os () =
-  let ic = Unix.open_process_in "uname -s" in
+let run_cmd cmd =
+  let ic = Unix.open_process_in cmd in
   let os = In_channel.input_line ic in
   ignore (Unix.close_process_in ic);
   os
+
+let uname_os () = run_cmd "uname -s"
+
+let arch () = run_cmd "opam var arch"
 
 module Sys_seq = STM_sequential.Make(SConf)
 module Sys_dom = STM_domain.Make(SConf)
@@ -326,7 +330,7 @@ module Sys_dom = STM_domain.Make(SConf)
 ;;
 QCheck_base_runner.run_tests_main [
     Sys_seq.agree_test              ~count:1000 ~name:"STM Sys test sequential";
-    if Sys.unix && uname_os () = Some "Linux"
+    if Sys.unix && (uname_os () = Some "Linux" || arch () = Some "arm64")
     then Sys_dom.agree_test_par     ~count:200  ~name:"STM Sys test parallel"
     else Sys_dom.neg_agree_test_par ~count:1000 ~name:"STM Sys test parallel"
   ]


### PR DESCRIPTION
This little PR
- makes the parallel `Sys` `STM` positive (not expected to fail) and
- reduces the `count` to 200

for the new shiny macOS arm64 runners.
This matches what we already do on Linux (Intel + arm64).

The PR thereby fixes #359 and helps to regain a nice all-green CI starting point.

On the branch CI run I can see this is already all green for Multicoretests-CI 
  https://github.com/ocaml-multicore/multicoretests/runs/14071705952