### PR TITLE
Switch STM_domain.agree_prop_par_asym to use Atomics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Next
+
+- #368: Switch `STM_domain.agree_prop_par_asym` from using
+  `Semaphore.Binary` to using an `int Atomic.t` which improves
+  the error rate across platforms and backends
+
 ## 0.2
 
 - #342: Add two submodules of combinators in `Util`:

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -42,15 +42,13 @@ module Make (Spec: Spec) = struct
   let agree_prop_par_asym (seq_pref, cmds1, cmds2) =
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
-    let sema = Semaphore.Binary.make false in
+    let wait = Atomic.make true in
     let child_dom =
       Domain.spawn (fun () ->
-          Semaphore.Binary.release sema;
+          Atomic.set wait false;
           try Ok (interp_sut_res sut cmds2) with exn -> Error exn)
     in
-    while not (Semaphore.Binary.try_acquire sema) do
-      Domain.cpu_relax ()
-    done;
+    while Atomic.get wait do Domain.cpu_relax() done;
     let parent_obs = try Ok (interp_sut_res sut cmds1) with exn -> Error exn in
     let child_obs = Domain.join child_dom in
     let () = Spec.cleanup sut in


### PR DESCRIPTION
I just got around to running a bit of statistics on `STM_domain.agree_prop_par_asym` for the `ref int` test.

Switching to use `Atomic` looks like a clear win when testing locally.
Over 10000 runs this represents a provable improvement at 95% confidence both when compiling to byte code:
```
$ dune exec src/statistics/z_test.exe 10000 317 10000 786
z-test of two proportions         
z = -14.527927
Is |z| = |-14.527927| > z_alpha2 = 1.960000 ?
Yes, null hypothesis rejected
```
and when compiling to native code:
```
$ dune exec src/statistics/z_test.exe 10000 785 10000 1879
z-test of two proportions         
z = -22.766211
Is |z| = |-22.766211| > z_alpha2 = 1.960000 ?
Yes, null hypothesis rejected
```

In both cases, the number of failed properties doubled!
Interestingly, native code is significantly better at causing trouble than bytecode.

Hopefully this should take care of #364 