### PR TITLE
Add the possibility to compute statistics

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -110,8 +110,6 @@ jobs:
 
     runs-on: ${{ inputs.runs_on }}
 
-    timeout-minutes: ${{ inputs.timeout }}
-
     outputs:
       skippart2: ${{ steps.winonlyone.outputs.skippart2 }}
 
@@ -305,10 +303,14 @@ jobs:
         if: env.ONLY_TEST == ''
 
       - name: Run the multicore test suite (Linux / macOS)
+        env:
+          QCHECK_STATISTICS_FILE:   'stats'
         run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice $SUBSUITE
         if: "runner.os != 'Windows' && env.ONLY_TEST == ''"
 
       - name: Run the multicore test suite (Windows / Cygwin)
+        env:
+          QCHECK_STATISTICS_FILE:   'stats'
         run: opam exec -- dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice @(-Split $Env:SUBSUITE)
         if: "runner.os == 'Windows' && env.ONLY_TEST == ''"
 

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -34,7 +34,7 @@ module Make (Spec: Spec) = struct
     let obs1 = match obs1 with Ok v -> v | Error exn -> raise exn in
     let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
     check_obs pref_obs obs1 obs2 Spec.init_state
-      || Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
+      || Util.fail_reportf "  Results incompatible with linearized model\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,obs1,obs2)
@@ -57,7 +57,7 @@ module Make (Spec: Spec) = struct
     let parent_obs = match parent_obs with Ok v -> v | Error exn -> raise exn in
     let child_obs = match child_obs with Ok v -> v | Error exn -> raise exn in
     check_obs pref_obs parent_obs child_obs Spec.init_state
-      || Test.fail_reportf "  Results incompatible with linearized model:\n\n%s"
+      || Util.fail_reportf "  Results incompatible with linearized model:\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35 ~center_prefix:false
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,parent_obs,child_obs)
@@ -66,7 +66,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make ~retries:10 ~max_gen ~count ~name
+    Util.make_test ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
@@ -76,7 +76,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make_neg ~retries:10 ~max_gen ~count ~name
+    Util.make_neg_test ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
@@ -86,7 +86,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make ~retries:10 ~max_gen ~count ~name
+    Util.make_test ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
@@ -96,7 +96,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make_neg ~retries:10 ~max_gen ~count ~name
+    Util.make_neg_test ~retries:10 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);

--- a/lib/STM_sequential.ml
+++ b/lib/STM_sequential.ml
@@ -24,13 +24,13 @@ module Make (Spec: Spec) = struct
     match res with
     | None -> true
     | Some trace ->
-      Test.fail_reportf "  Results incompatible with model\n%s"
+      Util.fail_reportf "  Results incompatible with model\n%s"
       @@ print_seq_trace trace
 
   let agree_test ~count ~name =
-    Test.make ~name ~count (arb_cmds Spec.init_state) agree_prop
+    Util.make_test ~name ~count (arb_cmds Spec.init_state) (Util.repeat 1 agree_prop)
 
   let neg_agree_test ~count ~name =
-    Test.make_neg ~name ~count (arb_cmds Spec.init_state) agree_prop
+    Util.make_neg_test ~name ~count (arb_cmds Spec.init_state) (Util.repeat 1 agree_prop)
 
   end

--- a/lib/STM_thread.ml
+++ b/lib/STM_thread.ml
@@ -33,7 +33,7 @@ module Make (Spec: Spec) = struct
     let obs1 = match !obs1 with Ok v -> v | Error exn -> raise exn in
     let obs2 = match !obs2 with Ok v -> v | Error exn -> raise exn in
     check_obs pref_obs obs1 obs2 Spec.init_state
-      || Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
+      || Util.fail_reportf "  Results incompatible with linearized model\n\n%s"
          @@ print_triple_vertical ~fig_indent:5 ~res_width:35
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,obs1,obs2)
@@ -43,7 +43,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 100 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make ~retries:15 ~max_gen ~count ~name
+    Util.make_test ~retries:15 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);
@@ -53,7 +53,7 @@ module Make (Spec: Spec) = struct
     let rep_count = 100 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
-    Test.make_neg ~retries:15 ~max_gen ~count ~name
+    Util.make_neg_test ~retries:15 ~max_gen ~count ~name
       (arb_cmds_triple seq_len par_len)
       (fun ((seq_pref,cmds1,cmds2) as triple) ->
          assume (all_interleavings_ok seq_pref cmds1 cmds2 Spec.init_state);

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -121,13 +121,13 @@ struct
     (* Linearization test *)
     let lin_test ~rep_count ~retries ~count ~name ~lin_prop =
       let arb_cmd_triple = arb_cmds_triple 20 12 in
-      Test.make ~count ~retries ~name
+      Util.make_test ~count ~retries ~name
         arb_cmd_triple (repeat rep_count lin_prop)
 
     (* Negative linearization test *)
     let neg_lin_test ~rep_count ~retries ~count ~name ~lin_prop =
       let arb_cmd_triple = arb_cmds_triple 20 12 in
-      Test.make_neg ~count ~retries ~name
+      Util.make_neg_test ~count ~retries ~name
         arb_cmd_triple (repeat rep_count lin_prop)
   end
 end

--- a/lib/lin_domain.ml
+++ b/lib/lin_domain.ml
@@ -24,7 +24,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
     let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
     let seq_sut = Spec.init () in
     check_seq_cons pref_obs obs1 obs2 seq_sut []
-      || QCheck.Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
+      || Util.fail_reportf "  Results incompatible with sequential execution\n\n%s"
          @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
               (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (Spec.show_res r))
               (pref_obs,obs1,obs2)

--- a/lib/lin_effect.ml
+++ b/lib/lin_effect.ml
@@ -107,7 +107,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
     let seq_sut = Spec.init () in
     (* exclude [Yield]s from sequential executions when searching for an interleaving *)
     EffTest.check_seq_cons (filter_res pref_obs) (filter_res !obs1) (filter_res !obs2) seq_sut []
-    || QCheck.Test.fail_reportf "  Results incompatible with linearized model\n\n%s"
+    || Util.fail_reportf "  Results incompatible with linearized model\n\n%s"
     @@ Util.print_triple_vertical ~fig_indent:5 ~res_width:35
       (fun (c,r) -> Printf.sprintf "%s : %s" (EffSpec.show_cmd c) (EffSpec.show_res r))
       (pref_obs,!obs1,!obs2)
@@ -115,13 +115,13 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
   let lin_test ~count ~name =
     let arb_cmd_triple = EffTest.arb_cmds_triple 20 12 in
     let rep_count = 1 in
-    QCheck.Test.make ~count ~retries:10 ~name
+    Util.make_test ~count ~retries:10 ~name
       arb_cmd_triple (Util.repeat rep_count lin_prop)
 
   let neg_lin_test ~count ~name =
     let arb_cmd_triple = EffTest.arb_cmds_triple 20 12 in
     let rep_count = 1 in
-    QCheck.Test.make_neg ~count ~retries:10 ~name
+    Util.make_neg_test ~count ~retries:10 ~name
       arb_cmd_triple (Util.repeat rep_count lin_prop)
 end
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -6,7 +6,8 @@ val repeat : int -> ('a -> bool) -> 'a -> bool
 (** [repeat num prop] iterates a property [prop] [num] times. The function stops
     early and returns false if just one of the iterations returns false.
     This is handy if the property outcome is non-determistic, for example,
-    if it depends on scheduling. *)
+    if it depends on scheduling.
+    TODO *)
 
 exception Timeout
 (** exception raised by [prop_timeout] and [fork_prop_with_timeout]. *)
@@ -161,3 +162,42 @@ module Equal : sig
   val equal_seq : 'a t -> 'a Seq.t t
   val equal_array : 'a t -> 'a array t
 end
+
+module Stats : sig
+  val enabled : bool
+  (** TODO *)
+end
+
+val make_test :
+  ?if_assumptions_fail:[ `Fatal | `Warning ] * float ->
+  ?count:int ->
+  ?long_factor:int ->
+  ?max_gen:int ->
+  ?max_fail:int ->
+  ?small:('a -> int) ->
+  ?retries:int ->
+  ?name:string ->
+  'a QCheck.arbitrary ->
+  ('a -> bool) ->
+  QCheck.Test.t
+(** TODO *)
+
+val make_neg_test :
+  ?if_assumptions_fail:[ `Fatal | `Warning ] * float ->
+  ?count:int ->
+  ?long_factor:int ->
+  ?max_gen:int ->
+  ?max_fail:int ->
+  ?small:('a -> int) ->
+  ?retries:int ->
+  ?name:string ->
+  'a QCheck.arbitrary ->
+  ('a -> bool) ->
+  QCheck.Test.t
+(** TODO *)
+
+val fail_reportf : ('a, Format.formatter, unit, bool) format4 -> 'a
+(** TODO *)
+
+val run_tests_main : ?argv:string array -> QCheck2.Test.t list -> 'a
+(** TODO *)

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -117,6 +117,6 @@ end
 
 module AT_domain = Lin_domain.Make_internal(AConf) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   AT_domain.neg_lin_test ~count:1000 ~name:"Lin Array test with Domain";
 ]

--- a/src/array/lin_tests_dsl.ml
+++ b/src/array/lin_tests_dsl.ml
@@ -28,6 +28,6 @@ end
 
 module AT_domain = Lin_domain.Make(AConf)
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   AT_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Array test with Domain";
 ]

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -121,7 +121,7 @@ end
 module ArraySTM_seq = STM_sequential.Make(AConf)
 module ArraySTM_dom = STM_domain.Make(AConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [ArraySTM_seq.agree_test         ~count ~name:"STM Array test sequential";
     ArraySTM_dom.neg_agree_test_par ~count ~name:"STM Array test parallel" (* this test is expected to fail *)

--- a/src/atomic/lin_tests.ml
+++ b/src/atomic/lin_tests.ml
@@ -189,7 +189,7 @@ end
 
 module A3T_domain = Lin_domain.Make_internal(A3Conf) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   AT_domain.lin_test  ~count:1000 ~name:"Lin Atomic test with Domain";
   A3T_domain.lin_test ~count:1000 ~name:"Lin Atomic3 test with Domain";
 ]

--- a/src/atomic/lin_tests_dsl.ml
+++ b/src/atomic/lin_tests_dsl.ml
@@ -16,6 +16,6 @@ end
 module Lin_atomic_domain = Lin_domain.Make (Atomic_spec)
 
 let () =
-  QCheck_base_runner.run_tests_main
+  Util.run_tests_main
     [ Lin_atomic_domain.lin_test ~count:1000 ~name:"Lin DSL Atomic test with Domain";
     ]

--- a/src/atomic/stm_tests.ml
+++ b/src/atomic/stm_tests.ml
@@ -83,7 +83,7 @@ end
 module AT_seq = STM_sequential.Make(CConf)
 module AT_dom = STM_domain.Make(CConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 250 in
    [AT_seq.agree_test     ~count ~name:"STM Atomic test sequential";
     AT_dom.agree_test_par ~count ~name:"STM Atomic test parallel";])

--- a/src/bigarray/lin_tests_dsl.ml
+++ b/src/bigarray/lin_tests_dsl.ml
@@ -28,6 +28,6 @@ end
 module BA1T = Lin_domain.Make(BA1Conf)
 
 let _ =
-  QCheck_base_runner.run_tests_main [
+  Util.run_tests_main [
     BA1T.neg_lin_test ~count:5000 ~name:"Lin DSL Bigarray.Array1 (of ints) test with Domain";
   ]

--- a/src/bigarray/stm_tests.ml
+++ b/src/bigarray/stm_tests.ml
@@ -92,7 +92,7 @@ end
 module BigArraySTM_seq = STM_sequential.Make(BAConf)
 module BigArraySTM_dom = STM_domain.Make(BAConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [BigArraySTM_seq.agree_test         ~count ~name:"STM BigArray test sequential";
     BigArraySTM_dom.neg_agree_test_par ~count ~name:"STM BigArray test parallel"

--- a/src/buffer/stm_tests.ml
+++ b/src/buffer/stm_tests.ml
@@ -144,7 +144,7 @@ end
 module BufferSTM_seq = STM_sequential.Make(BConf)
 module BufferSTM_dom = STM_domain.Make(BConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [BufferSTM_seq.agree_test         ~count ~name:"STM Buffer test sequential";
     BufferSTM_dom.neg_agree_test_par ~count ~name:"STM Buffer test parallel"])

--- a/src/bytes/lin_tests_dsl.ml
+++ b/src/bytes/lin_tests_dsl.ml
@@ -20,7 +20,7 @@ end
 module BT_domain = Lin_domain.Make(BConf)
 module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   BT_domain.lin_test ~count:1000 ~name:"Lin DSL Bytes test with Domain";
   BT_thread.lin_test ~count:1000 ~name:"Lin DSL Bytes test with Thread";
 ]

--- a/src/bytes/stm_tests.ml
+++ b/src/bytes/stm_tests.ml
@@ -101,7 +101,7 @@ end
 module BytesSTM_seq = STM_sequential.Make(ByConf)
 module BytesSTM_dom = STM_domain.Make(ByConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [BytesSTM_seq.agree_test     ~count ~name:"STM Bytes test sequential";
     BytesSTM_dom.neg_agree_test_par ~count ~name:"STM Bytes test parallel"

--- a/src/domain/domain_spawntree.ml
+++ b/src/domain/domain_spawntree.ml
@@ -72,7 +72,7 @@ let rec dom_interp a = function
     let ds = List.map (fun c -> Domain.spawn (fun () -> dom_interp a c)) cs in
     List.iter Domain.join ds
 
-let t ~max_height ~max_degree = Test.make
+let t ~max_height ~max_degree = Util.make_test
     ~name:"domain_spawntree - with Atomic"
     ~count:100
     ~retries:10
@@ -80,6 +80,7 @@ let t ~max_height ~max_degree = Test.make
     (make ~print:show_cmd ~shrink:shrink_cmd (gen max_height max_degree))
 
     ((*Util.fork_prop_with_timeout 30*) (* forking a fresh process starts afresh, it seems *)
+     Util.repeat 1
        (fun c ->
          (*Printf.printf "spawns: %i\n%!" (count_spawns c);*)
           (*Printf.printf "%s\n%!" (show_cmd c);*)
@@ -100,4 +101,4 @@ let test =
   else t ~max_height:3 ~max_degree:3
 
 ;;
-QCheck_base_runner.run_tests_main [test]
+Util.run_tests_main [test]

--- a/src/dynlink/lin_tests_dsl.ml
+++ b/src/dynlink/lin_tests_dsl.ml
@@ -34,6 +34,6 @@ let _ =
   if Sys.win32 then
     Printf.printf "negative Lin DSL Dynlink test with Domain disabled under Windows\n\n%!"
   else
-    QCheck_base_runner.run_tests_main [
+    Util.run_tests_main [
       DynT.neg_lin_test ~count:100 ~name:"negative Lin DSL Dynlink test with Domain";
     ]

--- a/src/floatarray/lin_tests_dsl.ml
+++ b/src/floatarray/lin_tests_dsl.ml
@@ -36,6 +36,6 @@ end
 module FAT = Lin_domain.Make(FAConf)
 
 let _ =
-  QCheck_base_runner.run_tests_main [
+  Util.run_tests_main [
     FAT.neg_lin_test ~count:1000 ~name:"Lin DSL Float.Array test with Domain";
   ]

--- a/src/floatarray/stm_tests.ml
+++ b/src/floatarray/stm_tests.ml
@@ -134,7 +134,7 @@ end
 module FloatArraySTM_seq = STM_sequential.Make(FAConf)
 module FloatArraySTM_dom = STM_domain.Make(FAConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [FloatArraySTM_seq.agree_test         ~count ~name:"STM Float Array test sequential";
     FloatArraySTM_dom.neg_agree_test_par ~count ~name:"STM Float Array test parallel"

--- a/src/hashtbl/lin_tests.ml
+++ b/src/hashtbl/lin_tests.ml
@@ -124,6 +124,6 @@ end
 
 module HT_domain = Lin_domain.Make_internal(HConf) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   HT_domain.neg_lin_test ~count:1000 ~name:"Lin Hashtbl test with Domain";
 ]

--- a/src/hashtbl/lin_tests_dsl.ml
+++ b/src/hashtbl/lin_tests_dsl.ml
@@ -25,6 +25,6 @@ end
 
 module HT_domain = Lin_domain.Make(HConf)
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
   HT_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Hashtbl test with Domain";
 ]

--- a/src/hashtbl/stm_tests.ml
+++ b/src/hashtbl/stm_tests.ml
@@ -135,7 +135,7 @@ end
 module HTest_seq = STM_sequential.Make(HConf)
 module HTest_dom = STM_domain.Make(HConf)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 200 in
    [HTest_seq.agree_test         ~count ~name:"STM Hashtbl test sequential";
     HTest_dom.neg_agree_test_par ~count ~name:"STM Hashtbl test parallel";

--- a/src/io/lin_tests.ml
+++ b/src/io/lin_tests.ml
@@ -128,7 +128,7 @@ module Out_channel_lin = Lin_domain.Make_internal (Out_channel_ops) [@@alert "-i
 module In_channel_lin = Lin_domain.Make_internal (In_channel_ops) [@@alert "-internal"]
 
 let () =
-  QCheck_base_runner.run_tests_main
+  Util.run_tests_main
     [ Out_channel_lin.lin_test ~count:1000 ~name:"Lin Out_channel test with domains";
       In_channel_lin.lin_test ~count:1000 ~name:"Lin In_channel test with domains";
     ]

--- a/src/io/lin_tests_dsl_domain.ml
+++ b/src/io/lin_tests_dsl_domain.ml
@@ -17,4 +17,4 @@ let tests =
     OC_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Out_channel test with Domain";
   ]
 
-let _ = QCheck_base_runner.run_tests_main tests
+let _ = Util.run_tests_main tests

--- a/src/io/lin_tests_dsl_thread.ml
+++ b/src/io/lin_tests_dsl_thread.ml
@@ -8,7 +8,7 @@ module IC_thread = Lin_thread.Make(ICConf) [@@alert "-experimental"]
 module OC_thread = Lin_thread.Make(OCConf) [@@alert "-experimental"]
 
 let _ =
-  QCheck_base_runner.run_tests_main [
+  Util.run_tests_main [
     IC_thread.neg_lin_test ~count:1000 ~name:"Lin DSL In_channel test with Thread";
     OC_thread.neg_lin_test ~count:1000 ~name:"Lin DSL Out_channel test with Thread";
   ]

--- a/src/lazy/lin_tests.ml
+++ b/src/lazy/lin_tests.ml
@@ -131,7 +131,7 @@ module LTfromfun = Lin_domain.Make_internal(struct
     let init () = Lazy.from_fun work
   end) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 100 in
    [LTlazy.neg_lin_test       ~count ~name:"Lin Lazy test with Domain";
     LTfromval.lin_test        ~count ~name:"Lin Lazy test with Domain from_val";

--- a/src/lazy/lin_tests_dsl.ml
+++ b/src/lazy/lin_tests_dsl.ml
@@ -65,7 +65,7 @@ module LTfromval_domain = Lin_domain.Make(LTfromvalAPI)
 module LTfromfunAPI = struct include LBase let init () = Lazy.from_fun work end
 module LTfromfun_domain = Lin_domain.Make(LTfromfunAPI)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 100 in
    [LTlazy_domain.neg_lin_test    ~count ~name:"Lin DSL Lazy test with Domain";
     LTfromval_domain.lin_test     ~count ~name:"Lin DSL Lazy test with Domain from_val";

--- a/src/lazy/stm_tests.ml
+++ b/src/lazy/stm_tests.ml
@@ -143,7 +143,7 @@ module LTfromfun_dom = STM_domain.Make(struct
     let init_sut () = Lazy.from_fun work
   end)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 200 in
    [LTlazy_seq.agree_test        ~count ~name:"STM Lazy test sequential";
     LTfromval_seq.agree_test     ~count ~name:"STM Lazy test sequential from_val";

--- a/src/neg_tests/lin_tests_domain.ml
+++ b/src/neg_tests/lin_tests_domain.ml
@@ -8,7 +8,7 @@ module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64)) [@alert "-int
 (** This is a driver of the negative tests over the Domain module *)
 
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 15000 in
    [RT_int_domain.neg_lin_test    ~count ~name:"Lin ref int test with Domain";
     RT_int64_domain.neg_lin_test  ~count ~name:"Lin ref int64 test with Domain";

--- a/src/neg_tests/lin_tests_dsl_domain.ml
+++ b/src/neg_tests/lin_tests_dsl_domain.ml
@@ -8,7 +8,7 @@ module CLT_int64_domain = Lin_domain.Make(CList_spec_int64)
 (** This is a driver of the negative tests over the Domain module *)
 
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 10000 in
    [RT_int_domain.neg_lin_test    ~count ~name:"Lin DSL ref int test with Domain";
     RT_int64_domain.neg_lin_test  ~count ~name:"Lin DSL ref int64 test with Domain";

--- a/src/neg_tests/lin_tests_dsl_effect.ml
+++ b/src/neg_tests/lin_tests_dsl_effect.ml
@@ -80,7 +80,7 @@ module CLT_int64_effect = Lin_effect.Make(CList_spec_int64) [@alert "-experiment
 module CLT_int64'_effect = Lin_effect.Make(CList_spec_int64') [@alert "-experimental"]
 
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
       RT_int_effect.lin_test     ~count ~name:"Lin DSL ref int test with Effect";

--- a/src/neg_tests/lin_tests_dsl_thread.ml
+++ b/src/neg_tests/lin_tests_dsl_thread.ml
@@ -8,7 +8,7 @@ module CLT_int_thread = Lin_thread.Make(CList_spec_int) [@alert "-experimental"]
 module CLT_int64_thread = Lin_thread.Make(CList_spec_int64) [@alert "-experimental"]
 
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [RT_int_thread.lin_test       ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
     RT_int64_thread.neg_lin_test ~count:15000 ~name:"Lin ref int64 test with Thread";

--- a/src/neg_tests/lin_tests_effect.ml
+++ b/src/neg_tests/lin_tests_effect.ml
@@ -148,7 +148,7 @@ end
 module CLT_int64_effect = Lin_effect.Make_internal(CLConf(Int64)) [@alert "-internal"]
 module CLT_int64'_effect = Lin_effect.Make_internal(CLConf_int64') [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 20_000 in [
       (* We don't expect the first four tests to fail as each `cmd` is completed before a `Yield` *)
       RT_int_effect.lin_test     ~count ~name:"Lin ref int test with Effect";

--- a/src/neg_tests/lin_tests_thread_conclist.ml
+++ b/src/neg_tests/lin_tests_thread_conclist.ml
@@ -17,4 +17,4 @@ let _ =
       [ List.hd tests ])
     else tests
   in
-  QCheck_base_runner.run_tests_main tests
+  Util.run_tests_main tests

--- a/src/neg_tests/lin_tests_thread_ref.ml
+++ b/src/neg_tests/lin_tests_thread_ref.ml
@@ -10,7 +10,7 @@ if Sys.backend_type = Sys.Bytecode
 then
   Printf.printf "Lin ref tests with Thread disabled under bytecode\n\n%!"
 else
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [RT_int_thread.lin_test       ~count       ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
     RT_int64_thread.neg_lin_test ~count:15000 ~name:"Lin ref int64 test with Thread"])

--- a/src/neg_tests/stm_tests_conclist.ml
+++ b/src/neg_tests/stm_tests_conclist.ml
@@ -63,7 +63,7 @@ module CLT_int_dom = STM_domain.Make(CLConf(Int))
 module CLT_int64_seq = STM_sequential.Make(CLConf(Int64))
 module CLT_int64_dom = STM_domain.Make(CLConf(Int64))
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [CLT_int_seq.agree_test           ~count ~name:"STM int CList test sequential";
     CLT_int64_seq.agree_test         ~count ~name:"STM int64 CList test sequential";

--- a/src/neg_tests/stm_tests_domain_ref.ml
+++ b/src/neg_tests/stm_tests_domain_ref.ml
@@ -3,7 +3,7 @@ open Stm_tests_spec_ref
 module RT_int   = STM_domain.Make(RConf_int)
 module RT_int64 = STM_domain.Make(RConf_int64)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   [RT_int.neg_agree_test_par        ~count:1000 ~name:"STM int ref test parallel";
    RT_int64.neg_agree_test_par      ~count:1000 ~name:"STM int64 ref test parallel";
    RT_int.neg_agree_test_par_asym   ~count:2000 ~name:"STM int ref test parallel asymmetric";

--- a/src/neg_tests/stm_tests_sequential_ref.ml
+++ b/src/neg_tests/stm_tests_sequential_ref.ml
@@ -3,7 +3,7 @@ open Stm_tests_spec_ref
 module RT_int_seq   = STM_sequential.Make(RConf_int)
 module RT_int64_seq = STM_sequential.Make(RConf_int64)
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   (let count = 1000 in
    [RT_int_seq.agree_test   ~count ~name:"STM int ref test sequential";
     RT_int64_seq.agree_test ~count ~name:"STM int64 ref test sequential";

--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -7,7 +7,7 @@ if Sys.backend_type = Sys.Bytecode
 then
   Printf.printf "STM ref tests with Thread disabled under bytecode\n\n%!"
 else
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
    RT_int64.neg_agree_test_conc ~count:1000 ~name:"STM int64 ref test with Thread";
   ]

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -170,7 +170,7 @@ module QMT_thread = Lin_thread.Make_internal(QMutexConf) [@alert "-internal"]
 module QT_domain  = Lin_domain.Make_internal(QConf) [@alert "-internal"]
 module QT_thread  = Lin_thread.Make_internal(QConf) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
     QMT_domain.lin_test    ~count:1000 ~name:"Lin Queue test with Domain and mutex";
     QMT_thread.lin_test    ~count:1000 ~name:"Lin Queue test with Thread and mutex";
     QT_domain.neg_lin_test ~count:1000 ~name:"Lin Queue test with Domain without mutex";

--- a/src/queue/lin_tests_dsl.ml
+++ b/src/queue/lin_tests_dsl.ml
@@ -21,7 +21,7 @@ module Lin_queue_domain = Lin_domain.Make(Queue_spec)
 module Lin_queue_thread = Lin_thread.Make(Queue_spec) [@alert "-experimental"]
 
 let () =
-  QCheck_base_runner.run_tests_main [
+  Util.run_tests_main [
     Lin_queue_domain.neg_lin_test ~count:1000 ~name:"Lin DSL Queue test with Domain";
     Lin_queue_thread.lin_test     ~count:250  ~name:"Lin DSL Queue test with Thread";
   ]

--- a/src/semaphore/stm_tests.ml
+++ b/src/semaphore/stm_tests.ml
@@ -76,7 +76,7 @@ module SCTest_seq = STM_sequential.Make(SCConf)
 module SCTest_dom = STM_domain.Make(SCConf)
 
 let _ =
-  QCheck_base_runner.run_tests_main
+  Util.run_tests_main
     (let count = 200 in
      [SCTest_seq.agree_test     ~count ~name:"STM Semaphore.Counting test sequential";
       SCTest_dom.agree_test_par ~count ~name:"STM Semaphore.Counting test parallel";

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -170,7 +170,7 @@ module ST_thread = Lin_thread.Make_internal(SConf) [@alert "-internal"]
 module SMT_domain = Lin_domain.Make_internal(SMutexConf) [@alert "-internal"]
 module SMT_thread = Lin_thread.Make_internal(SMutexConf) [@alert "-internal"]
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
     SMT_domain.lin_test    ~count:1000 ~name:"Lin Stack test with Domain and mutex";
     SMT_thread.lin_test    ~count:1000 ~name:"Lin Stack test with Thread and mutex";
     ST_domain.neg_lin_test ~count:1000 ~name:"Lin Stack test with Domain without mutex";

--- a/src/stack/lin_tests_dsl.ml
+++ b/src/stack/lin_tests_dsl.ml
@@ -31,4 +31,4 @@ let () =
       [ List.hd tests ])
     else tests
   in
-  QCheck_base_runner.run_tests_main tests
+  Util.run_tests_main tests

--- a/src/sys/stm_tests.ml
+++ b/src/sys/stm_tests.ml
@@ -328,7 +328,7 @@ module Sys_seq = STM_sequential.Make(SConf)
 module Sys_dom = STM_domain.Make(SConf)
 
 ;;
-QCheck_base_runner.run_tests_main [
+Util.run_tests_main [
     Sys_seq.agree_test              ~count:1000 ~name:"STM Sys test sequential";
     if Sys.unix && (uname_os () = Some "Linux" || arch () = Some "arm64")
     then Sys_dom.agree_test_par     ~count:200  ~name:"STM Sys test parallel"

--- a/src/thread/thread_createtree.ml
+++ b/src/thread/thread_createtree.ml
@@ -72,16 +72,16 @@ let rec thread_interp a = function
     let ts = List.map (fun c -> Thread.create (fun () -> thread_interp a c) ()) cs in
     List.iter Thread.join ts
 
-let t ~max_height ~max_degree = Test.make
+let t ~max_height ~max_degree = Util.make_test
     ~name:"thread_createtree - with Atomic"
     ~count:1000
     ~retries:100
     (make ~print:show_cmd ~shrink:shrink_cmd (gen max_height max_degree))
-    (fun c ->
+    (Util.repeat 1 (fun c ->
        (*Printf.printf "%s\n%!" (show_cmd c);*)
        let a = Atomic.make 0 in
        let () = thread_interp a c in
-       Atomic.get a = interp 0 c)
+       Atomic.get a = interp 0 c))
 
 let test =
   if Sys.word_size == 64
@@ -89,4 +89,4 @@ let test =
   else t ~max_height:3 ~max_degree:3
 
 ;;
-QCheck_base_runner.run_tests_main [test]
+Util.run_tests_main [test]

--- a/src/thread/thread_joingraph.ml
+++ b/src/thread/thread_joingraph.ml
@@ -104,9 +104,10 @@ let work () =
   done
 
 let test_tak_work ~thread_bound =
-  Test.make ~name:"Thread.create/join - tak work" ~count:100
+  Util.make_test ~name:"Thread.create/join - tak work" ~count:100
     (arb_deps thread_bound)
     ((*Util.fork_prop_with_timeout 30*)
+    Util.repeat 1
     (fun test_input ->
       (*Printf.printf "%s\n%!" (show_test_input test_input);*)
       let ps = build_dep_graph test_input work in
@@ -115,9 +116,9 @@ let test_tak_work ~thread_bound =
 
 (** In this test each created thread calls [Atomic.incr] - and then optionally join. *)
 let test_atomic_work ~thread_bound =
-  Test.make ~name:"Thread.create/join - atomic" ~count:500
+  Util.make_test ~name:"Thread.create/join - atomic" ~count:500
     (arb_deps thread_bound)
-    (fun test_input ->
+    (Util.repeat 1 (fun test_input ->
        let a = Atomic.make 0 in
        let ps = build_dep_graph test_input (fun () -> Atomic.incr a) in
        List.iteri (fun i p ->
@@ -125,13 +126,13 @@ let test_atomic_work ~thread_bound =
            then
              Thread.join p;
          ) ps;
-       Atomic.get a = test_input.num_threads)
+       Atomic.get a = test_input.num_threads))
 
 let bound_tak = if Sys.word_size == 64 then 100 else 16
 let bound_atomic = if Sys.word_size == 64 then 250 else 16
 
 ;;
-QCheck_base_runner.run_tests_main
+Util.run_tests_main
   [test_tak_work    ~thread_bound:bound_tak;
    test_atomic_work ~thread_bound:bound_atomic
   ]

--- a/src/threadomain/threadomain.ml
+++ b/src/threadomain/threadomain.ml
@@ -185,11 +185,11 @@ let main_test = Test.make ~name:"Mash up of threads and domains"
                           ~count:500
                           ~print:show_spawn_join
                           (Gen.sized_size nb_nodes gen_spawn_join)
-                          run_all_nodes
+                          (Util.repeat 1 run_all_nodes)
                           (* to debug deadlocks: *)
                           (* (Util.fork_prop_with_timeout 1 run_all_nodes) *)
 
 let _ =
-  QCheck_base_runner.run_tests_main [
+  Util.run_tests_main [
     main_test
   ]

--- a/test/cleanup_lin.ml
+++ b/test/cleanup_lin.ml
@@ -72,7 +72,7 @@ module RT = Lin_domain.Make_internal(RConf) [@alert "-internal"]
 ;;
 Test.check_exn
   (let seq_len,par_len = 20,15 in
-   Test.make ~count:1000 ~name:("exactly one-cleanup test")
+   Util.make_test ~count:1000 ~name:("exactly one-cleanup test")
      (RT.arb_cmds_triple seq_len par_len)
      (fun input ->
         try

--- a/test/cleanup_stm.ml
+++ b/test/cleanup_stm.ml
@@ -88,7 +88,7 @@ status := None;
 for _i=1 to 100 do
   try
     Test.check_exn ~rand
-      (Test.make ~count:1000 ~name:"STM ensure cleanup test parallel"
+      (Util.make_test ~count:1000 ~name:"STM ensure cleanup test parallel"
          (RT_dom.arb_cmds_triple 20 12) RT_dom.agree_prop_par) (* without retries *)
   with _e -> incr i; assert (!status = Some Cleaned);
 done;

--- a/test/mutable_set_v5.ml
+++ b/test/mutable_set_v5.ml
@@ -132,5 +132,5 @@ end
 
 module Lib_sequential = STM_sequential.Make(Lib_spec)
 
-let _ = QCheck_base_runner.run_tests_main
+let _ = Util.run_tests_main
     [Lib_sequential.agree_test ~count:100 ~name:"STM sequential tests"]


### PR DESCRIPTION
This adds the possibility to compute statistics (count all runs of a property, along with the number of times it fails and the number of times it triggers an exception) for all tests. The main goal is to provide a sound argument whether a given change has a (positive or negative) impact on the ability of a test to detect issues. It is an incomplete draft, but advanced enough that we can decide whether it should be completed.

As we have no statistics to back the assumption that this PR has no impact, it tries to be as non-intrusive as possible. Here is how it proposes to do this:

- statistics are enabled by setting the environment variable `$QCHECK_STATISTICS_FILE` to the path of a file in which the stats will be recorded (I think that adding a command-line option would require duplicating `QCheck_base_runner.Raw.parse_cli`, which I would rather avoid)
- a couple of QCheck functions are “routed” through `Util` so that their behaviours can be adapted when computing stats:
  - `fail_reportf` is reexported so that it returns `false` rather than raising an exception (so that failures and exceptions can be distinguished),
  - `make_neg_test` wraps `Test.make_neg` so that it uses `Test.make` when statistics are enabled (because tests will always report success, and count failures separately); `make_test` wraps `Test.make` for uniformity
  - `run_tests_main` is duplicated in order to run each test separately when statistics are enabled so that we can record the stats for each test separately and to enable the _long_ version of tests (so `$QCHECK_LONG_FACTOR` can be used to multiply the number of tests to run)

  Note that this routing could be useful also to add optional hooks before and after each test (what #365 and #367 have done by hand for weak and ephemeron tests).
- most of the counting logic is done in `Util.repeat`: when stats are enabled, it uses a different loop that will count iterations and negative outcomes rather than stop at the first failure; this means that even the tests not using repetitions are now wrapped into a `repeat 1` to get statistics working
- `Util.Stats.enabled` is exposed so that tests can choose a different repetition count depending on this.

A possible alternate design that would not rely quite so much on global state in `Util` (and would thus allow to use `run_tests` without splitting test lists) would be to use `Util.make_test` and `Util.make_neg_test` to expect a `Stats.t -> 'a -> bool` function (that would be the result of `repeat`, with the added benefit that the change of type detects places that are not updated...) and generate fresh stats for each test. It is not yet in that version of the PR because I’m not sure which one is the best choice.

To do before merging, if this proposal is good enough:
- choose one of the two possible designs,
- split up a commit with just the rerouting through `Util` to avoid useless history noise,
- cover the tests that are not yet covered (discovered through the experiment with the change in `repeat` and `make_test` signatures),
- document the new functions exposed by `Util` or the changes of behaviours,
- remove the commit that choose stats in GH CI runs,
- integrate weak and ephemeron tests in that standard workflow.

To do in a later PR:
- add dune targets that run the stats; I’d rather move that to a different PR because the way I have in mind to integrate that requires _a lot_ of boilerplate dune config so it would make sense to take advantage of this to also split the test suite into smaller parts (I’m thinking about 4 aliases: stable, experimental, complete (to cover the first two) and deprecated), along with whether stats should be enabled or not. A small script would generate all that dune config.