### PR TITLE
Move GitHub actions to test 5.1.0~beta1

### DIFF
--- a/.github/workflows/cygwin-510.yml
+++ b/.github/workflows/cygwin-510.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~alpha2+options+win
+      compiler: ocaml-variants.5.1.0~beta1+options+win
       cygwin: true
       timeout: 360
       subsuite: src/array src/atomic src/bigarray src/buffer src/bytes src/domain src/dynlink src/ephemeron src/floatarray src/hashtbl src/io
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~alpha2+options+win
+      compiler: ocaml-variants.5.1.0~beta1+options+win
       cygwin: true
       timeout: 360
       subsuite: src/lazy src/neg_tests src/queue src/semaphore src/stack src/statistics src/sys src/thread src/threadomain src/weak

--- a/.github/workflows/linux-510-32bit.yml
+++ b/.github/workflows/linux-510-32bit.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~alpha2+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.1.0~beta1+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-510-bytecode.yml
+++ b/.github/workflows/linux-510-bytecode.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~alpha2+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.1.0~beta1+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-510-debug.yml
+++ b/.github/workflows/linux-510-debug.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~alpha2'
+      compiler: 'ocaml-base-compiler.5.1.0~beta1'
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-510.yml
+++ b/.github/workflows/linux-510.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~alpha2'
+      compiler: 'ocaml-base-compiler.5.1.0~beta1'

--- a/.github/workflows/macosx-510.yml
+++ b/.github/workflows/macosx-510.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~alpha2'
+      compiler: 'ocaml-base-compiler.5.1.0~beta1'
       runs_on: 'macos-latest'

--- a/.github/workflows/windows-510-bytecode.yml
+++ b/.github/workflows/windows-510-bytecode.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~alpha2+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.1.0~beta1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/windows-510.yml
+++ b/.github/workflows/windows-510.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~alpha2+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.1.0~beta1+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
This PR moves the GitHub actions CI to test the fresh `5.1.0~beta1` release, by building on a custom Windows opam package as we've done for `5.1.0~alpha2` https://github.com/shym/custom-opam-repository/pull/1