### PR TITLE
Weak hashset adjustment

### DIFF
--- a/dune
+++ b/dune
@@ -94,6 +94,6 @@
     (write-file hoped "")
     (write-file failed-runs "")
     (run cmd /q /c
-     "for %G in (1,2,3,4, 5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20) do (echo Starting %G-th run && focusedtest.exe -v || echo %G >> failed-runs)")
+     "for %G in (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20) do (echo Starting %G-th run && focusedtest.exe -v || echo %G >> failed-runs)")
     ; edit the previous line to focus on a particular seed
     (diff failed-runs hoped)))))

--- a/src/weak/stm_tests_hashset.ml
+++ b/src/weak/stm_tests_hashset.ml
@@ -185,5 +185,5 @@ let status_seq =
 let () = Gc.full_major ()
 let status_par =
   run_tests
-    [ WeakHashsetSTM_dom.neg_agree_test_par ~count:2000 ~name:"STM Weak HashSet test parallel" ]
+    [ WeakHashsetSTM_dom.neg_agree_test_par ~count:5000 ~name:"STM Weak HashSet test parallel" ]
 let _ = exit (if status_seq=0 && status_par=0 then 0 else 1)


### PR DESCRIPTION
I just saw another occurrence failing to trigger a parallel STM Weak HashSet failure, this time under 5.1 bytecode:
https://github.com/ocaml-multicore/multicoretests/actions/runs/5488638494/jobs/10001760309
```
random seed: 192914563
generated error fail pass / total     time test name

[ ]    0    0    0    0 / 1000     0.0s STM Weak HashSet test sequential
[ ]    0    0    0    0 / 1000     0.0s STM Weak HashSet test sequential (generating)
[✓] 1000    0    0 1000 / 1000     2.7s STM Weak HashSet test sequential
================================================================================
success (ran 1 tests)
generated error fail pass / total     time test name

[ ]    0    0    0    0 / 2000     0.0s STM Weak HashSet test parallel
[ ]  742    0    0  742 / 2000    57.3s STM Weak HashSet test parallel
[ ] 1497    0    0 1497 / 2000   117.6s STM Weak HashSet test parallel
[✗] 2000    0    0 2000 / 2000   160.6s STM Weak HashSet test parallel
```

I therefore ran a bit of failure rate stats only to learn that the error rate is pretty slim under both native and bytecode:
```
jmi@MintPad:~/software/multicoretests-latest$ dune exec src/weak/stm_tests_hashset_stats.exe -- -v
Weak Hashset 5 / 10000              
jmi@MintPad:~/software/multicoretests-latest$ dune exec src/weak/stm_tests_hashset_stats.bc -- -v
Weak Hashset 5 / 10000              
```

This PR therefore raises the count from 2000 to 5000.
This decreases the chance of completing a non-error-triggering run from 37% to 0.8% if my calculations are right
$( 1 - 1/2000 ) ^{count}$.