### PR TITLE
`In_channel`: Generate and shrink bytes only on length

### DIFF
--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -9,7 +9,15 @@ module ICConf : Lin.Spec = struct
   let cleanup = In_channel.close
 
   open Lin
-  let int,int64,bytes = nat_small,nat64_small,bytes_small
+  let int,int64 = nat_small,nat64_small
+
+  let bytes =
+    let open QCheck in
+    let zeroed_bytes n = Bytes.make n '\000' in
+    let shrink b = Iter.map zeroed_bytes (Shrink.int (Bytes.length b))
+    and gen = Gen.map zeroed_bytes Gen.small_nat in
+    let bytes = make ~shrink ~small:Bytes.length ~print:Print.bytes gen in
+    gen_deconstructible bytes (print Lin.bytes) Bytes.equal
 
   let api = [
     (* Only one t is tested, so skip stdin and opening functions *)

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -5,7 +5,7 @@
 module ICConf : Lin.Spec = struct
   type t = In_channel.t
 
-  let init () = In_channel.open_bin Sys.argv.(0)
+  let init () = In_channel.open_bin Sys.executable_name
   let cleanup = In_channel.close
 
   open Lin

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -2,10 +2,26 @@
 (*                      Tests of in and out channels                      *)
 (* ********************************************************************** *)
 
+(* Try to find a text file rather than a binary to test In_channel, so
+   that input_line makes more sense *)
+let in_file =
+  let path0 = Filename.dirname Sys.executable_name
+  and up p = Filename.concat p Filename.parent_dir_name
+  and candidate p = Filename.concat p "dune" in
+  let path1 = up path0 in
+  let path2 = up path1 in
+  let path3 = up path2 in
+  let path4 = up path3 in
+  let candidates = List.map candidate [ path0; path1; path2; path3; path4 ] in
+  let existing = List.filter Sys.file_exists candidates in
+  match existing with
+  | [] -> Sys.executable_name
+  | f :: _ -> f
+
 module ICConf : Lin.Spec = struct
   type t = In_channel.t
 
-  let init () = In_channel.open_bin Sys.executable_name
+  let init () = In_channel.open_bin in_file
   let cleanup = In_channel.close
 
   open Lin


### PR DESCRIPTION
This PR spawned out of #373.

In `In_channel`, `bytes` are used as input buffers so only their lengths is relevant: generate and shrink them by taking only their lengths into account

It currently contains a focusing commit to remove before merging, so I set this PR as a draft.