### PR TITLE
Switch 5.1.0 workflows to rc1

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -192,7 +192,7 @@ jobs:
           opam-repositories: |
             local: ${{ github.workspace }}\.github\opam\custom
             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
-            override: https://github.com/shym/custom-opam-repository.git
+            override: https://github.com/jmid/custom-opam-repository.git#add-510rc1
             default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
             upstream: https://github.com/ocaml/opam-repository.git
           opam-depext: false
@@ -243,7 +243,7 @@ jobs:
           opam init --disable-sandboxing --auto-setup --bare
           opam repository add --all main "https://github.com/ocaml/opam-repository.git"
           opam repository add --all windows "https://github.com/ocaml-opam/opam-repository-mingw.git#sunset"
-          opam repository add --all override "https://github.com/shym/custom-opam-repository.git"
+          opam repository add --all override "https://github.com/jmid/custom-opam-repository.git#add-510rc1"
           opam repository add --all dra27 "https://github.com/dra27/opam-repository.git#windows-5.0"
           opam repository add --all local "./.github/opam/custom/"
           opam switch create default --repositories=dra27,override,windows,main --packages "${env:COMPILER}"

--- a/.github/workflows/cygwin-510.yml
+++ b/.github/workflows/cygwin-510.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~beta1+options+win
+      compiler: ocaml-variants.5.1.0~rc1+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci1'
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~beta1+options+win
+      compiler: ocaml-variants.5.1.0~rc1+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci2'

--- a/.github/workflows/linux-510-32bit.yml
+++ b/.github/workflows/linux-510-32bit.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~beta1+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.1.0~rc1+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-510-bytecode.yml
+++ b/.github/workflows/linux-510-bytecode.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~beta1+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.1.0~rc1+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-510-debug.yml
+++ b/.github/workflows/linux-510-debug.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~beta1'
+      compiler: 'ocaml-base-compiler.5.1.0~rc1'
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-510.yml
+++ b/.github/workflows/linux-510.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~beta1'
+      compiler: 'ocaml-base-compiler.5.1.0~rc1'

--- a/.github/workflows/macosx-510.yml
+++ b/.github/workflows/macosx-510.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~beta1'
+      compiler: 'ocaml-base-compiler.5.1.0~rc1'
       runs_on: 'macos-latest'

--- a/.github/workflows/windows-510-bytecode.yml
+++ b/.github/workflows/windows-510-bytecode.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~beta1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.1.0~rc1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/windows-510.yml
+++ b/.github/workflows/windows-510.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~beta1+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.1.0~rc1+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
This PR switches the GitHub action workflows to test `5.1.0~rc1`.

I've created a PR against `shym/custom-opam-repository` to switch under Mingw and Cygwin https://github.com/shym/custom-opam-repository/pull/2. Until that is merged and in the interest of testing `5.1.0~rc1` the most, the PR is temporarily using the relevant branch from `jmid/custom-opam-repository`