### PR TITLE
Lin Out_channel shrink cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+- #387: Reduce needless allocations in `Lin`'s sequential consistency
+  search, as part of an `Out_channel` test cleanup
 - #368: Switch `STM_domain.agree_prop_par_asym` from using
   `Semaphore.Binary` to using an `int Atomic.t` which improves
   the error rate across platforms and backends

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -47,6 +47,9 @@ struct
     (* plain interpreter of a cmd list *)
     let interp_plain sut cs = List.map (fun c -> (c, Spec.run c sut)) cs
 
+    (* plain interpreter ignoring the output and allocating less *)
+    let interp_plain_ignore sut cs = List.iter (fun c -> ignore (Spec.run c sut)) cs
+
     let rec gen_cmds fuel =
       Gen.(if fuel = 0
            then return []
@@ -113,7 +116,7 @@ struct
           ||
           (* rerun to get seq_sut to same cmd branching point *)
           (let seq_sut' = Spec.init () in
-           let _ = interp_plain seq_sut' (List.rev seq_trace) in
+           let _ = interp_plain_ignore seq_sut' (List.rev seq_trace) in
            if Spec.equal_res res2 (Spec.run c2 seq_sut')
            then check_seq_cons pref cs1 cs2' seq_sut' (c2::seq_trace)
            else (Spec.cleanup seq_sut'; false))

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -116,7 +116,7 @@ struct
           ||
           (* rerun to get seq_sut to same cmd branching point *)
           (let seq_sut' = Spec.init () in
-           let _ = interp_plain_ignore seq_sut' (List.rev seq_trace) in
+           interp_plain_ignore seq_sut' (List.rev seq_trace);
            if Spec.equal_res res2 (Spec.run c2 seq_sut')
            then check_seq_cons pref cs1 cs2' seq_sut' (c2::seq_trace)
            else (Spec.cleanup seq_sut'; false))

--- a/src/io/lin_tests.ml
+++ b/src/io/lin_tests.ml
@@ -148,13 +148,13 @@ module Out_channel_ops = struct
 
 end
 
-module Out_channel_lin = Lin_domain.Make_internal (Out_channel_ops) [@@alert "-internal"]
 module In_channel_lin = Lin_domain.Make_internal (In_channel_ops) [@@alert "-internal"]
+module Out_channel_lin = Lin_domain.Make_internal (Out_channel_ops) [@@alert "-internal"]
 
 let () =
   QCheck_base_runner.run_tests_main
-    [ Out_channel_lin.lin_test ~count:1000 ~name:"Lin Out_channel test with domains";
-      In_channel_lin.lin_test ~count:1000 ~name:"Lin In_channel test with domains";
+    [ In_channel_lin.lin_test ~count:1000 ~name:"Lin In_channel test with domains";
+      Out_channel_lin.lin_test ~count:1000 ~name:"Lin Out_channel test with domains";
     ]
 
 let () =

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -107,7 +107,7 @@ module OCConf : Lin.Spec = struct
     val_freq 10 "Out_channel.close"            Out_channel.close            (t @-> returning_or_exc unit) ;
     val_freq 10 "Out_channel.close_noerr"      Out_channel.close_noerr      (t @-> returning unit) ;
     val_freq 10 "Out_channel.flush"            Out_channel.flush            (t @-> returning_or_exc unit) ;
-    val_freq  1 "Out_channel.flush_all"        Out_channel.flush_all        (unit @-> returning_or_exc unit) ;
+  (*val_freq  1 "Out_channel.flush_all"        Out_channel.flush_all        (unit @-> returning_or_exc unit) ;*)
     val_freq 10 "Out_channel.output_char"      Out_channel.output_char      (t @-> char @-> returning_or_exc unit) ;
     val_freq 10 "Out_channel.output_byte"      Out_channel.output_byte      (t @-> int @-> returning_or_exc unit) ;
     val_freq 10 "Out_channel.output_string"    Out_channel.output_string    (t @-> string @-> returning_or_exc unit) ;

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -76,7 +76,14 @@ module OCConf : Lin.Spec = struct
   let lift f (_, chan) = f chan
 
   open Lin
-  let int,int64,string,bytes = nat_small,nat64_small,string_small,bytes_small
+  let int,int64,string = nat_small,nat64_small,string_small
+
+  (* disable bytes char shrinking as too many shrinking candidates
+     triggers long Out_channel shrink runs on Mingw + Cygwin *)
+  let bytes =
+    let bytes = QCheck.(set_shrink Shrink.(bytes ~shrink:nil) bytes_small) in
+    gen_deconstructible bytes (print Lin.bytes) Bytes.equal
+
   let api = [
     (* Only one t is tested, so skip stdout, stderr and opening functions *)
 

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -101,21 +101,21 @@ module OCConf : Lin.Spec = struct
     (* val_ "Out_channel.with_open_text"   Out_channel.with_open_text   (string @-> (t @-> 'a) @-> returning 'a) ; *)
     (* val_ "Out_channel.with_open_gen"    Out_channel.with_open_gen    (open_flag list @-> int @-> string @-> (t @-> 'a) @-> returning 'a) ; *)
 
-    val_ "Out_channel.seek"             Out_channel.seek             (t @-> int64 @-> returning_or_exc unit) ;
-    val_freq 3 "Out_channel.pos"        Out_channel.pos              (t @-> returning_or_exc int64) ;
-    val_freq 3 "Out_channel.length"     Out_channel.length           (t @-> returning_or_exc int64) ;
-    val_ "Out_channel.close"            Out_channel.close            (t @-> returning_or_exc unit) ;
-    val_ "Out_channel.close_noerr"      Out_channel.close_noerr      (t @-> returning unit) ;
-    val_ "Out_channel.flush"            Out_channel.flush            (t @-> returning_or_exc unit) ;
-    val_ "Out_channel.flush_all"        Out_channel.flush_all        (unit @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_char"      Out_channel.output_char      (t @-> char @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_byte"      Out_channel.output_byte      (t @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_string"    Out_channel.output_string    (t @-> string @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_bytes"     Out_channel.output_bytes     (t @-> bytes @-> returning_or_exc unit) ;
-    val_ "Out_channel.output"           Out_channel.output           (t @-> bytes @-> int @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_substring" Out_channel.output_substring (t @-> string @-> int @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.set_binary_mode"  Out_channel.set_binary_mode  (t @-> bool @-> returning_or_exc unit) ;
-    val_ "Out_channel.set_buffered"     Out_channel.set_buffered     (t @-> bool @-> returning_or_exc unit) ;
-    val_ "Out_channel.is_buffered"      Out_channel.is_buffered      (t @-> returning_or_exc bool) ;
+    val_freq 10 "Out_channel.seek"             Out_channel.seek             (t @-> int64 @-> returning_or_exc unit) ;
+    val_freq 20 "Out_channel.pos"              Out_channel.pos              (t @-> returning_or_exc int64) ;
+    val_freq 20 "Out_channel.length"           Out_channel.length           (t @-> returning_or_exc int64) ;
+    val_freq 10 "Out_channel.close"            Out_channel.close            (t @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.close_noerr"      Out_channel.close_noerr      (t @-> returning unit) ;
+    val_freq 10 "Out_channel.flush"            Out_channel.flush            (t @-> returning_or_exc unit) ;
+    val_freq  1 "Out_channel.flush_all"        Out_channel.flush_all        (unit @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output_char"      Out_channel.output_char      (t @-> char @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output_byte"      Out_channel.output_byte      (t @-> int @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output_string"    Out_channel.output_string    (t @-> string @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output_bytes"     Out_channel.output_bytes     (t @-> bytes @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output"           Out_channel.output           (t @-> bytes @-> int @-> int @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.output_substring" Out_channel.output_substring (t @-> string @-> int @-> int @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.set_binary_mode"  Out_channel.set_binary_mode  (t @-> bool @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.set_buffered"     Out_channel.set_buffered     (t @-> bool @-> returning_or_exc unit) ;
+    val_freq 10 "Out_channel.is_buffered"      Out_channel.is_buffered      (t @-> returning_or_exc bool) ;
   ]
 end

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -65,15 +65,17 @@ end
 module OCConf : Lin.Spec = struct
   (* a path and an open channel to that file; we need to keep the path
      to cleanup after the test run *)
-  type t = string * Out_channel.t
+  type t = Out_channel.t
+  let path = ref ""
 
-  let init () = Filename.open_temp_file "lin-dsl-" ""
-  let cleanup (path, chan) =
-    Out_channel.close chan ;
-    Sys.remove path
+  let init () =
+    let p,ch = Filename.open_temp_file "lin-dsl-" "" in
+    path := p;
+    ch
 
-  (* turn [f: Out_channel.t -> ...] into [lift f: t -> ...] *)
-  let lift f (_, chan) = f chan
+  let cleanup chan =
+    Out_channel.close chan;
+    Sys.remove !path
 
   open Lin
   let int,int64 = nat_small,nat64_small
@@ -99,21 +101,21 @@ module OCConf : Lin.Spec = struct
     (* val_ "Out_channel.with_open_text"   Out_channel.with_open_text   (string @-> (t @-> 'a) @-> returning 'a) ; *)
     (* val_ "Out_channel.with_open_gen"    Out_channel.with_open_gen    (open_flag list @-> int @-> string @-> (t @-> 'a) @-> returning 'a) ; *)
 
-    val_ "Out_channel.seek"             (lift Out_channel.seek)             (t @-> int64 @-> returning_or_exc unit) ;
-    val_freq 3 "Out_channel.pos"        (lift Out_channel.pos)              (t @-> returning_or_exc int64) ;
-    val_freq 3 "Out_channel.length"     (lift Out_channel.length)           (t @-> returning_or_exc int64) ;
-    val_ "Out_channel.close"            (lift Out_channel.close)            (t @-> returning_or_exc unit) ;
-    val_ "Out_channel.close_noerr"      (lift Out_channel.close_noerr)      (t @-> returning unit) ;
-    val_ "Out_channel.flush"            (lift Out_channel.flush)            (t @-> returning_or_exc unit) ;
-    val_ "Out_channel.flush_all"              Out_channel.flush_all         (unit @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_char"      (lift Out_channel.output_char)      (t @-> char @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_byte"      (lift Out_channel.output_byte)      (t @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_string"    (lift Out_channel.output_string)    (t @-> string @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_bytes"     (lift Out_channel.output_bytes)     (t @-> bytes @-> returning_or_exc unit) ;
-    val_ "Out_channel.output"           (lift Out_channel.output)           (t @-> bytes @-> int @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.output_substring" (lift Out_channel.output_substring) (t @-> string @-> int @-> int @-> returning_or_exc unit) ;
-    val_ "Out_channel.set_binary_mode"  (lift Out_channel.set_binary_mode)  (t @-> bool @-> returning_or_exc unit) ;
-    val_ "Out_channel.set_buffered"     (lift Out_channel.set_buffered)     (t @-> bool @-> returning_or_exc unit) ;
-    val_ "Out_channel.is_buffered"      (lift Out_channel.is_buffered)      (t @-> returning_or_exc bool) ;
+    val_ "Out_channel.seek"             Out_channel.seek             (t @-> int64 @-> returning_or_exc unit) ;
+    val_freq 3 "Out_channel.pos"        Out_channel.pos              (t @-> returning_or_exc int64) ;
+    val_freq 3 "Out_channel.length"     Out_channel.length           (t @-> returning_or_exc int64) ;
+    val_ "Out_channel.close"            Out_channel.close            (t @-> returning_or_exc unit) ;
+    val_ "Out_channel.close_noerr"      Out_channel.close_noerr      (t @-> returning unit) ;
+    val_ "Out_channel.flush"            Out_channel.flush            (t @-> returning_or_exc unit) ;
+    val_ "Out_channel.flush_all"        Out_channel.flush_all        (unit @-> returning_or_exc unit) ;
+    val_ "Out_channel.output_char"      Out_channel.output_char      (t @-> char @-> returning_or_exc unit) ;
+    val_ "Out_channel.output_byte"      Out_channel.output_byte      (t @-> int @-> returning_or_exc unit) ;
+    val_ "Out_channel.output_string"    Out_channel.output_string    (t @-> string @-> returning_or_exc unit) ;
+    val_ "Out_channel.output_bytes"     Out_channel.output_bytes     (t @-> bytes @-> returning_or_exc unit) ;
+    val_ "Out_channel.output"           Out_channel.output           (t @-> bytes @-> int @-> int @-> returning_or_exc unit) ;
+    val_ "Out_channel.output_substring" Out_channel.output_substring (t @-> string @-> int @-> int @-> returning_or_exc unit) ;
+    val_ "Out_channel.set_binary_mode"  Out_channel.set_binary_mode  (t @-> bool @-> returning_or_exc unit) ;
+    val_ "Out_channel.set_buffered"     Out_channel.set_buffered     (t @-> bool @-> returning_or_exc unit) ;
+    val_ "Out_channel.is_buffered"      Out_channel.is_buffered      (t @-> returning_or_exc bool) ;
   ]
 end

--- a/src/io/lin_tests_spec_io.ml
+++ b/src/io/lin_tests_spec_io.ml
@@ -76,10 +76,13 @@ module OCConf : Lin.Spec = struct
   let lift f (_, chan) = f chan
 
   open Lin
-  let int,int64,string = nat_small,nat64_small,string_small
+  let int,int64 = nat_small,nat64_small
 
-  (* disable bytes char shrinking as too many shrinking candidates
+  (* disable string and bytes char shrinking as too many shrinking candidates
      triggers long Out_channel shrink runs on Mingw + Cygwin *)
+  let string =
+    let string = QCheck.(set_shrink Shrink.(string ~shrink:nil) string_small) in
+    gen_deconstructible string (print Lin.string) String.equal
   let bytes =
     let bytes = QCheck.(set_shrink Shrink.(bytes ~shrink:nil) bytes_small) in
     gen_deconstructible bytes (print Lin.bytes) Bytes.equal


### PR DESCRIPTION
This PR contains a range of adjustments to address the long shrinking sequences reported in #378:
- bf617290641d234f951600d33fa455d42256f1da and d5ff92a21ccbce6e84eb75d7d58e39cf10a8290d disable `char` element shrinking inside `bytes` and `string`s for the test
- 2433827343b1a80030dae97943fe969403cd70fe removes the `lift` combinator to reduce allocations
- ba20a6f8aee7b7aaf2a498d00345c4e2cbce2f00 adjusts the `cmd` frequencies
- 6c8db20adee709998417dd73da2ece6ff792512f drops `flush_all` entirely
- Finally e1a1de31a6cff43649e27810d804fafce3e6f256 reduces overall `Lin` allocations during `check_seq_cons` and should thus benefit other `Lin` tests too.

Overall, this makes the test behaviour reasonable. Below I include a CI summary table from running 20 focused tests across the 2 CI systems (I note runs taking more than 1000s as "outliers"). Observations:
- There's a trend of more outliers+timeouts after 5.0 - extra GC activity on +5.1.0 has been confirmed with `perf` and `olly gc-stats` measurements
- Disabling the test on macOS should be kept for now, an explanation would be nice though
- There was a crazy linux 5.1 debug 12514.3s outlier!

Overall the PR offers improvements, not the final word. They should help reduce false CI alarms though.

The last two commits 460b97c88439eac44a23eb81856977b19066d4cd and f7223d66b17148e91c90887a7d8d56fec318fe9b update the plain `Lin` `Out_channel` test to move it closer feature-wise to the `Lin DSL` version. These are steps towards creating an standalone reproducer for the extra +5.1.0 GC activity.



| | Target            | Outliers                                        | Timeout | Remarks |
|-|-------------------|-------------------------------------------------|---------|---------|
|✅|Linux 5.1          | -
|✅|Linux trunk        | 1973.0s
|❌|Linux 5.1 debug    | 12514.3s                                        | 12th run
|✅|Linux trunk debug  | 1462.0s 2350.7s
|✅|32bit trunk        | -
|✅|32bit 5.1          | -
|✅|Bytecode 5.1       | -
|✅|Bytecode trunk     | -
|  | | |
|✅|linux-arm64-5.0    | - |
|✅|linux-arm64-5.1    | 2367.5s 1150.1s 1360.5s 3558.0s
|✅|linux-arm64-5.2    | 1426.0s 1416.6s 1435.6s 1160.6s
| | | |
|✅|linux-s390x-5.1    | 1493.5s
|✅|linux-s390x-5.2    | -
| | | |
|❌|linux-ppc64le-5.2  | 2497.0s 1434.2s 3345.5s 3099.9s 1852.6s 2503.3s | 11th run
| | | |
|❌|macOS 5.1          | 7728.8s 1371.7s                                 | 3rd run
|❌|macOS trunk        | -                                               | 2nd run
|✅|macos-arm64-5.0    | 2090.3s
|❌|macOS-arm64-5.1    | 3017.1s 3278.3s 2001.6s 1961.0s 1866.6s 2803.1s | 10th run | 6/9 w/no counterexample!
|❌|macOS-arm64-5.2    | 3988.2s 3447.5s 3344.8s 2651.1s 3579.0s         | 6th run  | 5/5 w/no counterexample!
| | | |
|✅|Windows 5.1        | 1030.1s 2523.1s
|✅|Windows trunk      | 2471.4s 1139.8s 2522.6s
|✅|Win bytecode 5.1   | 1391.8s 3730.3s
|✅|Win bytecode trunk | -
| | | |
|✅|Cygwin 5.1         | 1004.0s 1206.1s
|✅|Cygwin trunk       | 1010.6s


