### PR TITLE
Disable cmd shrinking for int64 ref Thread test

### DIFF
--- a/src/neg_tests/lin_tests_thread_ref.ml
+++ b/src/neg_tests/lin_tests_thread_ref.ml
@@ -3,7 +3,10 @@ open Lin_tests_common
 (** This is a driver of the negative ref tests over the Thread module *)
 
 module RT_int_thread = Lin_thread.Make_internal(RConf_int) [@alert "-internal"]
-module RT_int64_thread = Lin_thread.Make_internal(RConf_int64) [@alert "-internal"]
+module RT_int64_thread = Lin_thread.Make_internal(struct
+    include RConf_int64
+    let shrink_cmd = QCheck.Shrink.nil
+  end ) [@alert "-internal"]
 
 ;;
 if Sys.backend_type = Sys.Bytecode


### PR DESCRIPTION
We are seeing long `src/neg_tests/lin_tests_thread_ref.exe` causing timeouts and long runs, primarily on Cygwin part 2 (examples below).

Since the experimental `Lin` `Thread` mode does not produce test failures as consistently as the `Domain` mode, this little PR disables `cmd` argument shrinking for the test, to limit how many shrinking candidates we have to traverse.

I've run focused tests which shows runs limited to at most 771.6s on Cygwin with the fix:
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6066711863/job/16457611765 5.1
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6066711878/job/16457612074 trunk
Interesting observation unrelated to this PR: the first (positive test) goes from 600-800s on `5.1` to about 1200s on `trunk` (which causes the former not to complete 20 iterations before the 6h timeout)


Examples of timeouts and long runs:
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6049285277/job/16426696553
  timeout during `9221.8s Lin ref int64 test with Thread (shrinking:   22.0013)`
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6042037294/job/16404453112
  long run `5144.7s Lin ref int64 test with Thread`
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6026531927/job/16358872865
  timeout during `11039.8s Lin ref int64 test with Thread (shrinking:   50.0002)`
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6026072299/job/16356758666
  long run `2381.5s Lin ref int64 test with Thread`
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6026072300/job/16358585587
  timeout during `8343.3s Lin ref int64 test with Thread (shrinking:   38.0002)`
- https://github.com/ocaml-multicore/multicoretests/actions/runs/6025647317/job/16355293724
  long run `3214.6s Lin ref int64 test with Thread`