### PR TITLE
Increasing test count of STM int64 ref Thread test

### DIFF
--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -9,5 +9,5 @@ then
 else
 QCheck_base_runner.run_tests_main
   [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
-   RT_int64.neg_agree_test_conc ~count:1000 ~name:"STM int64 ref test with Thread";
+   RT_int64.neg_agree_test_conc ~count:2500 ~name:"STM int64 ref test with Thread";
   ]


### PR DESCRIPTION
We are seeing occasional failures to trigger a `STM int64 ref Thread` negative test, e.g., here on macOS ARM64 5.0:
https://ocaml-multicoretests.ci.dev:8100/job/2023-09-04/192503-ci-ocluster-build-e5c445#L1466
```
random seed: 409068930
generated error fail pass / total     time test name

[ ]    0    0    0    0 /  250     0.0s STM int ref test with Thread
[ ]    0    0    0    0 /  250     0.0s STM int ref test with Thread (generating)
[✓]  250    0    0  250 /  250     2.9s STM int ref test with Thread

[ ]    0    0    0    0 / 1000     0.0s STM int64 ref test with Thread
[✗] 1000    0    0 1000 / 1000    11.2s STM int64 ref test with Thread

--- Failure --------------------------------------------------------------------

Test STM int64 ref test with Thread failed:

Negative test STM int64 ref test with Thread succeeded but was expected to fail
```

This little PR therefore raises the count from 1000 to 2500.