### PR TITLE
Add Lin Domain.DLS test

### DIFF
--- a/src/domain/dune
+++ b/src/domain/dune
@@ -17,3 +17,11 @@
  (libraries util qcheck-core qcheck-core.runner)
  (action (run %{test} --verbose))
 )
+
+(test
+ (name lin_tests_dsl_dls)
+ (modules lin_tests_dsl_dls)
+ (package multicoretests)
+ (libraries qcheck-lin.domain)
+ (action (run %{test} --verbose))
+)

--- a/src/domain/lin_tests_dsl_dls.ml
+++ b/src/domain/lin_tests_dsl_dls.ml
@@ -1,0 +1,25 @@
+open Domain
+open Lin
+
+module DLSConf = struct
+  type t = int DLS.key
+  let init () = DLS.new_key (fun () -> 0) (* without split from parent *)
+  let cleanup _ = ()
+  let int = int_small
+  let api = [
+    val_ "DLS.get" DLS.get (t @-> returning int) ;
+    val_ "DLS.set" DLS.set (t @-> int @-> returning unit) ;
+  ]
+end
+
+module DLSN = Lin_domain.Make (DLSConf)
+module DLST = Lin_domain.Make (struct
+    include DLSConf
+    let init () = (* get and set will see the parent's key *)
+      DLS.new_key ~split_from_parent:(fun i -> i) (fun () -> 0)
+  end)
+;;
+QCheck_base_runner.run_tests_main [
+  DLSN.neg_lin_test ~count:100 ~name:"Lin DSL Domain.DLS negative test with Domain";
+  DLST.lin_test     ~count:75  ~name:"Lin DSL Domain.DLS test with Domain";
+]


### PR DESCRIPTION
This PR adds a quick Lin stress test of `Domain.DLS`.

It uses only one `DLS.key` for a start - not impressive but it is a start.
We might revisit it based on `multiple-ts` or consider replacing it by an `STM` test later.

Without the optional `~split_from_parent` the child domain does not inherit the key, which makes for a fast negative test.
I did notice that the test takes longer and longer as it progresses, which may be due to the inability to remove `DSL.key`s again. For this reason, it seems faster to run the negative test first... 
We might consider (a) running the property/test in child domain or (b) splitting the two tests to run in separate processes.