### PR TITLE
Switch 5.1.0 GitHub action workflows to 5.1.0~rc3

### DIFF
--- a/.github/workflows/cygwin-510.yml
+++ b/.github/workflows/cygwin-510.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc2+options+win
+      compiler: ocaml-variants.5.1.0~rc3+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci1'
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc2+options+win
+      compiler: ocaml-variants.5.1.0~rc3+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci2'

--- a/.github/workflows/linux-510-32bit.yml
+++ b/.github/workflows/linux-510-32bit.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc2+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-510-bytecode.yml
+++ b/.github/workflows/linux-510-bytecode.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc2+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-510-debug.yml
+++ b/.github/workflows/linux-510-debug.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc2'
+      compiler: 'ocaml-base-compiler.5.1.0~rc3'
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-510-fp.yml
+++ b/.github/workflows/linux-510-fp.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc1+options,ocaml-option-fp'
+      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-fp'
       timeout: 240

--- a/.github/workflows/linux-510.yml
+++ b/.github/workflows/linux-510.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc2'
+      compiler: 'ocaml-base-compiler.5.1.0~rc3'

--- a/.github/workflows/macosx-510.yml
+++ b/.github/workflows/macosx-510.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc2'
+      compiler: 'ocaml-base-compiler.5.1.0~rc3'
       runs_on: 'macos-latest'

--- a/.github/workflows/windows-510-bytecode.yml
+++ b/.github/workflows/windows-510-bytecode.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc2+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.1.0~rc3+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/windows-510.yml
+++ b/.github/workflows/windows-510.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc2+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.1.0~rc3+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
This PR switches the 5.1.0 GitHub action workflows to `5.1.0~rc3`.
The most exiting part is spotting that `.github/workflows/linux-510-fp.yml` was using `5.1.0~rc1`... :sweat_smile: 
Almost nothing to see here, move along!
