### PR TITLE
Bump 510 workflows to the 5.1.0 release

### DIFF
--- a/.github/workflows/cygwin-510.yml
+++ b/.github/workflows/cygwin-510.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc3+options+win
+      compiler: ocaml-variants.5.1.0+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci1'
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc3+options+win
+      compiler: ocaml-variants.5.1.0+options+win
       cygwin: true
       timeout: 360
       dune_alias: 'ci2'

--- a/.github/workflows/linux-510-32bit.yml
+++ b/.github/workflows/linux-510-32bit.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.1.0+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-510-bytecode.yml
+++ b/.github/workflows/linux-510-bytecode.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.1.0+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-510-debug.yml
+++ b/.github/workflows/linux-510-debug.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc3'
+      compiler: 'ocaml-base-compiler.5.1.0'
       dune_profile: 'debug-runtime'
       runparam: 'v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-510-fp.yml
+++ b/.github/workflows/linux-510-fp.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.0~rc3+options,ocaml-option-fp'
+      compiler: 'ocaml-variants.5.1.0+options,ocaml-option-fp'
       timeout: 240

--- a/.github/workflows/linux-510.yml
+++ b/.github/workflows/linux-510.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc3'
+      compiler: 'ocaml-base-compiler.5.1.0'

--- a/.github/workflows/macosx-510.yml
+++ b/.github/workflows/macosx-510.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.0~rc3'
+      compiler: 'ocaml-base-compiler.5.1.0'
       runs_on: 'macos-latest'

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -18,7 +18,8 @@ jobs:
           - 4.13.x
           - 4.14.x
           - 5.0.0
-          - ocaml-variants.5.1.0+trunk
+          - 5.1.0
+          - ocaml-variants.5.2.0+trunk
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/windows-510-bytecode.yml
+++ b/.github/workflows/windows-510-bytecode.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc3+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.1.0+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/windows-510.yml
+++ b/.github/workflows/windows-510.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.0~rc3+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.1.0+options+win,ocaml-option-mingw
       timeout: 240

--- a/README.md
+++ b/README.md
@@ -396,8 +396,8 @@ The sequential `STM` tests of `Array`, `Bytes`, and `Float.Array`
 would [trigger segfaults on ppc64](https://github.com/ocaml/ocaml/issues/12482)
 
 
-Frame pointer `Effect` crashes (new, codegen)
----------------------------------------------
+Frame pointer `Effect` crashes (new, fixed, codegen)
+----------------------------------------------------
 
 Negative `Lin` `Effect` tests exercising exceptions for unhandled
 `Effect`s triggered a [crash on a frame pointer switch](https://github.com/ocaml/ocaml/pull/12535)


### PR DESCRIPTION
As the title says, this PR bumps the 510 workflows to the 5.1.0 release.

I also spotted that the 5.1.0 opam install workflow was using `5.1.0+trunk` - which [is marked as not `available` with with 5.1.0 release](https://github.com/Octachron/opam-repository/blob/69174a86b42ba9050fd57b152dd543fb48e47924/packages/ocaml-variants/ocaml-variants.5.1.0%2Btrunk/opam#L11) causing it to fail. The PR therefore switches to 5.1.0 there too and adds an entry for `5.2.0+trunk`.

Finally, I snuck in an unrelated update to mark the framepointer `Effect` crash issue as `fixed`.