### PR TITLE
Run debug-runtime workflows with a reduced minor heap

### DIFF
--- a/.github/workflows/linux-500-debug.yml
+++ b/.github/workflows/linux-500-debug.yml
@@ -11,5 +11,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       dune_profile: 'debug-runtime'
-      runparam: 'v=0,V=1'
+      runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-510-debug.yml
+++ b/.github/workflows/linux-510-debug.yml
@@ -8,5 +8,5 @@ jobs:
     with:
       compiler: 'ocaml-base-compiler.5.1.0'
       dune_profile: 'debug-runtime'
-      runparam: 'v=0,V=1'
+      runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-520-debug-trunk.yml
+++ b/.github/workflows/linux-520-debug-trunk.yml
@@ -9,5 +9,5 @@ jobs:
       compiler: 'ocaml-variants.5.2.0+trunk'
       compiler_git_ref: refs/heads/trunk
       dune_profile: 'debug-runtime'
-      runparam: 'v=0,V=1'
+      runparam: 's=4096,v=0,V=1'
       timeout: 240


### PR DESCRIPTION
This little PR reduces the minor heap size of the debug-runtime workflows.
I'm expecting the reduced size to stress-test the GC-logic more than the default size.

The `s=4096` words matches that of [the ocaml/ocaml debug runtime workflow](https://github.com/ocaml/ocaml/blob/ed7b3824a260ec20a694f5070f42a7215303f8bc/.github/workflows/build.yml#L201).

Finally, the reduced size was instrumental in triggering and reproducing [the recently fixed assertion race condition](https://github.com/ocaml/ocaml/pull/12707).
