### PR TITLE
Actions update

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -211,7 +211,7 @@ jobs:
         if: "runner.os == 'Windows' && inputs.cygwin"
 
       - name: Install Cygwin (in particular OPAM) (Cygwin)
-        uses: cygwin/cygwin-install-action@v3
+        uses: cygwin/cygwin-install-action@v4
         with:
           packages: opam
           install-dir: 'D:\cygwin'

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -110,7 +110,7 @@ jobs:
         if: "runner.os == 'Windows' && inputs.cygwin"
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pre-setup ($PATH, cache prefix, custom OPAM package for the compiler)
         id: presetup

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache opam
         id: cache-opam

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install OCaml compiler
         uses: ocaml/setup-ocaml@v2


### PR DESCRIPTION
This little PR updates a couple of our GitHub Actions to the latest releases:
- `actions/checkout@v4` 
- `cygwin/cygwin-install-action@v4`

I don't expect any immediate improvement by doing so, but we may benefit from future ones by doing so.