### PR TITLE
Disable Lin_thread Queue test under bytecode

### DIFF
--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -21,7 +21,14 @@ module Lin_queue_domain = Lin_domain.Make(Queue_spec)
 module Lin_queue_thread = Lin_thread.Make(Queue_spec) [@alert "-experimental"]
 
 let () =
-  QCheck_base_runner.run_tests_main [
+  let tests = [
     Lin_queue_domain.neg_lin_test ~count:1000 ~name:"Lin Queue test with Domain";
     Lin_queue_thread.lin_test     ~count:250  ~name:"Lin Queue test with Thread";
-  ]
+  ] in
+  let tests =
+    if Sys.backend_type = Sys.Bytecode then (
+      Printf.printf "Lin Queue test with Thread disabled under bytecode\n\n%!";
+      [ List.hd tests ])
+    else tests
+  in
+  QCheck_base_runner.run_tests_main tests


### PR DESCRIPTION
This PR disables the `Lin_thread` `Queue` test under bytecode which is the cause of false alarms, reported in #363.

The `Lin_thread`-mode is still experimental - and a9b2cc1f from #285 already disabled the `Stack` and `CList` ones for this reason. In view of that, this PR simply follows suit.

Fixes #363