### PR TITLE
Strengthen mutable_set_v5 expect test against timing differences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-- ...
+- #415: Remove `--verbose` in internal `mutable_set_v5` expect test to avoid
+  a test failure on a slow machine
 
 ## 0.3
 

--- a/test/dune
+++ b/test/dune
@@ -91,7 +91,7 @@
  (package qcheck-stm)
  (libraries qcheck-stm.sequential threads.posix)
  (action
-  (with-accepted-exit-codes 1 (run ./%{test} --verbose --seed 229109553))))
+  (with-accepted-exit-codes 1 (run ./%{test} --seed 229109553))))
 
 (test
  (name stm_next_state_exc)

--- a/test/mutable_set_v4.expected.32
+++ b/test/mutable_set_v4.expected.32
@@ -1,6 +1,4 @@
 [2Krandom seed: 229109553
-generated error fail pass / total     time test name
-[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)[2K[[31;1m✗[0m]    2    0    1    1 /  100     0.0s STM sequential tests
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 

--- a/test/mutable_set_v4.expected.64
+++ b/test/mutable_set_v4.expected.64
@@ -1,6 +1,4 @@
 [2Krandom seed: 229109553
-generated error fail pass / total     time test name
-[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)[2K[[31;1m✗[0m]    2    0    1    1 /  100     0.0s STM sequential tests
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 

--- a/test/mutable_set_v5.expected.32
+++ b/test/mutable_set_v5.expected.32
@@ -1,6 +1,4 @@
 [2Krandom seed: 229109553
-generated error fail pass / total     time test name
-[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)[2K[[31;1m✗[0m]    2    0    1    1 /  100     0.0s STM sequential tests
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 

--- a/test/mutable_set_v5.expected.64
+++ b/test/mutable_set_v5.expected.64
@@ -1,6 +1,4 @@
 [2Krandom seed: 229109553
-generated error fail pass / total     time test name
-[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests[2K[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)[2K[[31;1m✗[0m]    2    0    1    1 /  100     0.0s STM sequential tests
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 


### PR DESCRIPTION
The internal STM test `mutable_set_v5.ml` is currently run with `--verbose` which includes timing (`0.0s`) and subsequently diffed as an expect test. This creates the possibility of test failures due to a timing difference if it is run on a particular slow (CI) machine. 

I just had this happen to me on the CI of an unrelated branch which happened to take `0.1s` instead:
https://github.com/ocaml-multicore/multicoretests/actions/runs/6946194440/job/18897107446
```
STM test exception during next_state sequential failed with Random_next_state_failure as expected
STM test exception during next_state parallel failed with Random_next_state_failure as expected
diff --git a/_build/default/test/mutable_set_v5.expected b/_build/default/test/mutable_set_v5.output
old mode 100755
new mode 100644
index 84ab110..ef19a64
--- a/_build/default/test/mutable_set_v5.expected
File "test/mutable_set_v5.expected", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/mutable_set_v5.expected _build/default/test/mutable_set_v5.output
Command exited with code 1.
File "test/mutable_set_v5.expected", line 1, characters 0-0:
/usr/bin/git --no-pager diff --no-index --color=always -u _build/default/test/mutable_set_v5.expected _build/default/test/mutable_set_v5.output
Command exited with code 1.
+++ b/_build/default/test/mutable_set_v5.output
@@ -1,6 +1,6 @@
 
random seed: 229109553
 generated error fail pass / total     time test name
-
[ ]    0    0    0    0 /  100     0.0s STM sequential tests
[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)
[✗]    2    0    1    1 /  100     0.0s STM sequential tests
+
[ ]    0    0    0    0 /  100     0.0s STM sequential tests
[ ]    0    0    0    0 /  100     0.0s STM sequential tests (generating)
[✗]    2    0    1    1 /  100     0.1s STM sequential tests
 
 --- Failure --------------------------------------------------------------------
 
Error: Process completed with exit code 1.
```

This little PR therefore removes the `--verbose` option for this expect test.