### PR TITLE
Merge Cygwin CI workflow parts

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -64,10 +64,6 @@ on:
           Defaults to custom_compiler_version chunked at [+~-]
         type: string
         default: ''
-    outputs:
-      skippart2:
-        description: 'Whether Part 2 (Cygwin workflow) should be skipped (because we are running only one test)'
-        value: ${{ jobs.test.outputs.skipnextjob }}
 
 jobs:
   test:
@@ -91,9 +87,6 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
 
     timeout-minutes: ${{ inputs.timeout }}
-
-    outputs:
-      skipnextjob: ${{ steps.mainstep.outputs.skipnextjob }}
 
     steps:
       - name: Configure environment (Cygwin)

--- a/.github/workflows/cygwin-51x.yml
+++ b/.github/workflows/cygwin-51x.yml
@@ -3,22 +3,10 @@ name: Cygwin 5.1
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  part1:
+  build:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
       compiler: ocaml-variants.5.1.1~rc1+options+win
       cygwin: true
       timeout: 360
-      dune_alias: 'ci1'
-
-  part2:
-    needs: part1
-    if: ${{ always() && needs.part1.outputs.skippart2 != 'true' }}
-    uses: ./.github/workflows/common.yml
-    with:
-      runs_on: windows-latest
-      compiler: ocaml-variants.5.1.1~rc1+options+win
-      cygwin: true
-      timeout: 360
-      dune_alias: 'ci2'

--- a/.github/workflows/cygwin-520-trunk.yml
+++ b/.github/workflows/cygwin-520-trunk.yml
@@ -3,7 +3,7 @@ name: Cygwin trunk
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  part1:
+  build:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
@@ -11,16 +11,3 @@ jobs:
       cygwin: true
       compiler_git_ref: refs/heads/trunk
       timeout: 360
-      dune_alias: 'ci1'
-
-  part2:
-    needs: part1
-    if: ${{ always() && needs.part1.outputs.skippart2 != 'true' }}
-    uses: ./.github/workflows/common.yml
-    with:
-      runs_on: windows-latest
-      compiler: ocaml.5.2.0
-      cygwin: true
-      compiler_git_ref: refs/heads/trunk
-      timeout: 360
-      dune_alias: 'ci2'

--- a/dune
+++ b/dune
@@ -44,10 +44,6 @@
  (action
   (no-infer
    (progn
-    (system "echo skipnextjob=true >> \"%{env:GITHUB_OUTPUT=dummy_file}\"")
-     ; ^ this is to ensure only one job is run in multi-job GitHub
-     ; workflows (only Cygwin at the moment)
-
     (write-file hoped "")
     (write-file failed-runs "")
     (bash
@@ -63,10 +59,6 @@
  (action
   (no-infer
    (progn
-    (system "echo skipnextjob=true >> %{env:GITHUB_OUTPUT=dummy_file}")
-     ; ^ this is to ensure only one job is run in multi-job GitHub
-     ; workflows (only Cygwin at the moment)
-
     (write-file hoped "")
     (write-file failed-runs "")
     (run cmd /q /c

--- a/dune
+++ b/dune
@@ -25,36 +25,6 @@
   (alias_rec %{env:DUNE_CI_ALIAS=runtest})))
   ; (alias_rec focusedtest)))
 
-(alias
- (name ci1)
- (package multicoretests)
- (deps
-  (alias_rec src/array/runtest)
-  (alias_rec src/atomic/runtest)
-  (alias_rec src/bigarray/runtest)
-  (alias_rec src/buffer/runtest)
-  (alias_rec src/bytes/runtest)
-  (alias_rec src/domain/runtest)
-  (alias_rec src/dynlink/runtest)
-  (alias_rec src/ephemeron/runtest)
-  (alias_rec src/floatarray/runtest)
-  (alias_rec src/hashtbl/runtest)
-  (alias_rec src/io/runtest)))
-
-(alias
- (name ci2)
- (package multicoretests)
- (deps
-  (alias_rec src/lazy/runtest)
-  (alias_rec src/neg_tests/runtest)
-  (alias_rec src/queue/runtest)
-  (alias_rec src/semaphore/runtest)
-  (alias_rec src/stack/runtest)
-  (alias_rec src/sys/runtest)
-  (alias_rec src/thread/runtest)
-  (alias_rec src/threadomain/runtest)
-  (alias_rec src/weak/runtest)))
-
 ; @focusedtest
 ; repeat a single test a couple of times
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This PR merges the two GitHub actions workflow parts for Cygwin into a single one.

Initially, the split was done out of necessity in https://github.com/ocaml-multicore/multicoretests/pull/305 and https://github.com/ocaml-multicore/multicoretests/pull/313 as the Cygwin port initially was too slow to complete within the 6h timeout!

Since then we have seen general OCaml (GC) improvements, meaning that the 2-part Cygwin CI workflow would complete in about 2x45m, and thus opening up for a workflow merge incl. saving time on storing and restoring the state.

Finally I offer two data points from a trial run of this branch:
- [`5.1.1~rc1` completed in 1h16m](https://github.com/ocaml-multicore/multicoretests/actions/runs/7142221653/job/19451051986)
- [`trunk` completed in 1h11m](https://github.com/ocaml-multicore/multicoretests/actions/runs/7142221650/job/19451052012)