### PR TITLE
Move GitHub action workflows to 5.1.1

### DIFF
--- a/.github/workflows/cygwin-51x.yml
+++ b/.github/workflows/cygwin-51x.yml
@@ -7,6 +7,6 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.1~rc1+options+win
+      compiler: ocaml-variants.5.1.1+options+win
       cygwin: true
       timeout: 360

--- a/.github/workflows/linux-51x-32bit.yml
+++ b/.github/workflows/linux-51x-32bit.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.1~rc1+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.1.1+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-51x-bytecode.yml
+++ b/.github/workflows/linux-51x-bytecode.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.1~rc1+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.1.1+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-51x-debug.yml
+++ b/.github/workflows/linux-51x-debug.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.1~rc1'
+      compiler: 'ocaml-base-compiler.5.1.1'
       dune_profile: 'debug-runtime'
       runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-51x-fp.yml
+++ b/.github/workflows/linux-51x-fp.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.1.1~rc1+options,ocaml-option-fp'
+      compiler: 'ocaml-variants.5.1.1+options,ocaml-option-fp'
       timeout: 240

--- a/.github/workflows/linux-51x.yml
+++ b/.github/workflows/linux-51x.yml
@@ -6,4 +6,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.1~rc1'
+      compiler: 'ocaml-base-compiler.5.1.1'

--- a/.github/workflows/macosx-51x.yml
+++ b/.github/workflows/macosx-51x.yml
@@ -6,5 +6,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.1.1~rc1'
+      compiler: 'ocaml-base-compiler.5.1.1'
       runs_on: 'macos-latest'

--- a/.github/workflows/mingw-51x-bytecode.yml
+++ b/.github/workflows/mingw-51x-bytecode.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.1~rc1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.1.1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/mingw-51x.yml
+++ b/.github/workflows/mingw-51x.yml
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.1.1~rc1+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.1.1+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
This PR moves the GitHub action workflows from `5.1.1~rc1` to `5.1.1`.

Since this release includes two assertion error fixes, this should take care of (some of) the failures we have been seeing.