### PR TITLE
Increase count for STM Weak test parallel

### DIFF
--- a/src/weak/stm_tests.ml
+++ b/src/weak/stm_tests.ml
@@ -130,5 +130,5 @@ let status_seq =
 let () = Gc.full_major ()
 let status_par =
   run_tests
-    [ WeakSTM_dom.neg_agree_test_par        ~count:2000 ~name:"STM Weak test parallel"; ]
+    [ WeakSTM_dom.neg_agree_test_par        ~count:5000 ~name:"STM Weak test parallel"; ]
 let _ = exit (if status_seq=0 && status_par=0 then 0 else 1)


### PR DESCRIPTION
As #406 shows, the parallel `STM Weak` test occasionally fails to trigger on s390x, thus resulting in a false alarm.

This 1-character PR therefore bumps the test `count`.
Since this is a negative test stopping on the first counterexample, all platforms except s390x should be unaffected.
On Linux/s390x this should however increase the chance of triggering the issue.