### PR TITLE
Separate workflows for the 5.2 branch

### DIFF
--- a/.github/workflows/cygwin-51x.yml
+++ b/.github/workflows/cygwin-51x.yml
@@ -1,6 +1,11 @@
 name: Cygwin 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cygwin-520-trunk.yml
+++ b/.github/workflows/cygwin-520-trunk.yml
@@ -1,4 +1,4 @@
-name: Cygwin trunk
+name: Cygwin 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -9,5 +9,5 @@ jobs:
       runs_on: windows-latest
       compiler: ocaml.5.2.0
       cygwin: true
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 360

--- a/.github/workflows/cygwin-520-trunk.yml
+++ b/.github/workflows/cygwin-520-trunk.yml
@@ -1,6 +1,11 @@
 name: Cygwin 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cygwin-530-trunk.yml
+++ b/.github/workflows/cygwin-530-trunk.yml
@@ -1,6 +1,11 @@
 name: Cygwin trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cygwin-530-trunk.yml
+++ b/.github/workflows/cygwin-530-trunk.yml
@@ -1,0 +1,13 @@
+name: Cygwin trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.3.0
+      cygwin: true
+      compiler_git_ref: refs/heads/trunk
+      timeout: 360

--- a/.github/workflows/linux-51x-32bit.yml
+++ b/.github/workflows/linux-51x-32bit.yml
@@ -1,6 +1,11 @@
 name: 32bit 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-51x-bytecode.yml
+++ b/.github/workflows/linux-51x-bytecode.yml
@@ -1,6 +1,11 @@
 name: Bytecode 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-51x-debug.yml
+++ b/.github/workflows/linux-51x-debug.yml
@@ -1,6 +1,11 @@
 name: Linux 5.1 debug
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-51x-fp.yml
+++ b/.github/workflows/linux-51x-fp.yml
@@ -1,6 +1,11 @@
 name: FP 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-51x.yml
+++ b/.github/workflows/linux-51x.yml
@@ -1,6 +1,11 @@
 name: Linux 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk-32bit.yml
+++ b/.github/workflows/linux-520-trunk-32bit.yml
@@ -1,4 +1,4 @@
-name: 32bit trunk
+name: 32bit 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk,ocaml-option-32bit'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 240

--- a/.github/workflows/linux-520-trunk-32bit.yml
+++ b/.github/workflows/linux-520-trunk-32bit.yml
@@ -1,6 +1,11 @@
 name: 32bit 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk-bytecode.yml
+++ b/.github/workflows/linux-520-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: Bytecode trunk
+name: Bytecode 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk,ocaml-option-bytecode-only'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 240

--- a/.github/workflows/linux-520-trunk-bytecode.yml
+++ b/.github/workflows/linux-520-trunk-bytecode.yml
@@ -1,6 +1,11 @@
 name: Bytecode 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk-debug.yml
+++ b/.github/workflows/linux-520-trunk-debug.yml
@@ -1,4 +1,4 @@
-name: Linux trunk debug
+name: Linux 5.2 debug
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,7 +7,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       dune_profile: 'debug-runtime'
       runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-520-trunk-debug.yml
+++ b/.github/workflows/linux-520-trunk-debug.yml
@@ -1,6 +1,11 @@
 name: Linux 5.2 debug
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk-fp.yml
+++ b/.github/workflows/linux-520-trunk-fp.yml
@@ -1,4 +1,4 @@
-name: FP trunk
+name: FP 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk,ocaml-option-fp'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 240

--- a/.github/workflows/linux-520-trunk-fp.yml
+++ b/.github/workflows/linux-520-trunk-fp.yml
@@ -1,6 +1,11 @@
 name: FP 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk.yml
+++ b/.github/workflows/linux-520-trunk.yml
@@ -1,6 +1,11 @@
 name: Linux 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-520-trunk.yml
+++ b/.github/workflows/linux-520-trunk.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: Linux 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,4 +7,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2

--- a/.github/workflows/linux-530-trunk-32bit.yml
+++ b/.github/workflows/linux-530-trunk-32bit.yml
@@ -1,6 +1,11 @@
 name: 32bit trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-530-trunk-32bit.yml
+++ b/.github/workflows/linux-530-trunk-32bit.yml
@@ -1,0 +1,11 @@
+name: 32bit trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-32bit'
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-530-trunk-bytecode.yml
+++ b/.github/workflows/linux-530-trunk-bytecode.yml
@@ -1,0 +1,11 @@
+name: Bytecode trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-bytecode-only'
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-530-trunk-bytecode.yml
+++ b/.github/workflows/linux-530-trunk-bytecode.yml
@@ -1,6 +1,11 @@
 name: Bytecode trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-530-trunk-debug.yml
+++ b/.github/workflows/linux-530-trunk-debug.yml
@@ -1,0 +1,13 @@
+name: Linux trunk debug
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      dune_profile: 'debug-runtime'
+      runparam: 's=4096,v=0,V=1'
+      timeout: 240

--- a/.github/workflows/linux-530-trunk-debug.yml
+++ b/.github/workflows/linux-530-trunk-debug.yml
@@ -1,6 +1,11 @@
 name: Linux trunk debug
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-530-trunk-fp.yml
+++ b/.github/workflows/linux-530-trunk-fp.yml
@@ -1,6 +1,11 @@
 name: FP trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/linux-530-trunk-fp.yml
+++ b/.github/workflows/linux-530-trunk-fp.yml
@@ -1,0 +1,11 @@
+name: FP trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-fp'
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-530-trunk.yml
+++ b/.github/workflows/linux-530-trunk.yml
@@ -1,0 +1,10 @@
+name: Linux trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk

--- a/.github/workflows/linux-530-trunk.yml
+++ b/.github/workflows/linux-530-trunk.yml
@@ -1,6 +1,11 @@
 name: Linux trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macosx-51x.yml
+++ b/.github/workflows/macosx-51x.yml
@@ -1,6 +1,11 @@
 name: macOS 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macosx-520-trunk.yml
+++ b/.github/workflows/macosx-520-trunk.yml
@@ -1,4 +1,4 @@
-name: macOS trunk
+name: macOS 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -7,5 +7,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.2.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       runs_on: 'macos-latest'

--- a/.github/workflows/macosx-520-trunk.yml
+++ b/.github/workflows/macosx-520-trunk.yml
@@ -1,6 +1,11 @@
 name: macOS 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macosx-530-trunk.yml
+++ b/.github/workflows/macosx-530-trunk.yml
@@ -1,6 +1,11 @@
 name: macOS trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macosx-530-trunk.yml
+++ b/.github/workflows/macosx-530-trunk.yml
@@ -1,0 +1,11 @@
+name: macOS trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      runs_on: 'macos-latest'

--- a/.github/workflows/mingw-51x-bytecode.yml
+++ b/.github/workflows/mingw-51x-bytecode.yml
@@ -1,6 +1,11 @@
 name: MinGW bytecode 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mingw-51x.yml
+++ b/.github/workflows/mingw-51x.yml
@@ -1,6 +1,11 @@
 name: MinGW 5.1
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mingw-520-trunk-bytecode.yml
+++ b/.github/workflows/mingw-520-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: MinGW bytecode trunk
+name: MinGW bytecode 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -8,5 +8,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.2.0,ocaml-option-mingw,ocaml-option-bytecode-only
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 240

--- a/.github/workflows/mingw-520-trunk-bytecode.yml
+++ b/.github/workflows/mingw-520-trunk-bytecode.yml
@@ -1,6 +1,11 @@
 name: MinGW bytecode 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mingw-520-trunk.yml
+++ b/.github/workflows/mingw-520-trunk.yml
@@ -1,6 +1,11 @@
 name: MinGW 5.2
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mingw-520-trunk.yml
+++ b/.github/workflows/mingw-520-trunk.yml
@@ -1,4 +1,4 @@
-name: MinGW trunk
+name: MinGW 5.2
 
 on: [push, pull_request, workflow_dispatch]
 
@@ -8,5 +8,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.2.0,ocaml-option-mingw
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.2
       timeout: 240

--- a/.github/workflows/mingw-530-trunk-bytecode.yml
+++ b/.github/workflows/mingw-530-trunk-bytecode.yml
@@ -1,0 +1,12 @@
+name: MinGW bytecode trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.3.0,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/mingw-530-trunk-bytecode.yml
+++ b/.github/workflows/mingw-530-trunk-bytecode.yml
@@ -1,6 +1,11 @@
 name: MinGW bytecode trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/mingw-530-trunk.yml
+++ b/.github/workflows/mingw-530-trunk.yml
@@ -1,0 +1,12 @@
+name: MinGW trunk
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.3.0,ocaml-option-mingw
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/mingw-530-trunk.yml
+++ b/.github/workflows/mingw-530-trunk.yml
@@ -1,6 +1,11 @@
 name: MinGW trunk
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -4,7 +4,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Multicore tests
 [![MinGW 5.2.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-520-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-520-trunk-bytecode.yml)
 [![Cygwin 5.2.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520-trunk.yml)
 
+[![Linux 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml)
+[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-530-trunk.yml)
+[![Linux 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml)
+[![Linux 5.3.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml)
+[![Linux 32-bit 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml)
+[![Linux FP 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-fp.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-fp.yml)
+[![MinGW 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-530-trunk.yml)
+[![MinGW 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-530-trunk-bytecode.yml)
+[![Cygwin 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-530-trunk.yml)
+
 Property-based tests of (parts of) the OCaml multicore compiler and run time.
 
 This project contains


### PR DESCRIPTION
This PR
- adds separate `5.3+trunk` workflows to follow `trunk`
- updates the `5.2+trunk` workflows to follow the `5.2` branch on ocaml/ocaml

Finally, to reduce CI CPU cycles, it adjusts the yaml-workflows so that pushes from me do not trigger double runs for both the push and for the PR.