### PR TITLE
Disable 'Lin.Internal CList int test with Thread' under bytecode

### DIFF
--- a/src/neg_tests/lin_internal_tests_thread_conclist.ml
+++ b/src/neg_tests/lin_internal_tests_thread_conclist.ml
@@ -6,15 +6,11 @@ module CLT_int_thread = Lin_thread.Make_internal(CLConf (Int)) [@alert "-interna
 module CLT_int64_thread = Lin_thread.Make_internal(CLConf (Int64)) [@alert "-internal"]
 
 let _ =
-  let count = 1000 in
-  let tests = [
-    CLT_int_thread.lin_test   ~count ~name:"Lin.Internal CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    CLT_int64_thread.lin_test ~count ~name:"Lin.Internal CList int64 test with Thread" (* not triggering context switch, unfortunately *)
-  ] in
-  let tests =
-    if Sys.backend_type = Sys.Bytecode then (
-      Printf.printf "Lin.Internal CList int64 test with Thread disabled under bytecode\n\n%!";
-      [ List.hd tests ])
-    else tests
-  in
-  QCheck_base_runner.run_tests_main tests
+  if Sys.backend_type = Sys.Bytecode then
+    Printf.printf "Lin.Internal CList tests with Thread disabled under bytecode\n\n%!"
+  else
+    let count = 1000 in
+    QCheck_base_runner.run_tests_main [
+      CLT_int_thread.lin_test   ~count ~name:"Lin.Internal CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+      CLT_int64_thread.lin_test ~count ~name:"Lin.Internal CList int64 test with Thread" (* not triggering context switch, unfortunately *)
+    ]


### PR DESCRIPTION
OCaml's systhread context switching varies between the native and bytecode modes.
This is challenging to the experimental `Thread` modes and the package tests of it.
As a result
- both `Lin.Internal ref int/int64 test with Thread` have been disabled in bytecode mode
- the `Lin.Internal CList int64 test with Thread` has also been disabled in bytecode mode

This left `Lin.Internal CList int test with Thread` - which is marked as a positive test, but would occasionally find an unexpected counterexample in bytecode mode, causing a false alarm #358 - most recently in both `bytecode trunk` runs from #434.

This PR thus disables `Lin.Internal CList int test with Thread` in bytecode mode too.
It should eliminate another cause of false alarms.

Fixes #358