### PR TITLE
Reduce 51x CI runs

### DIFF
--- a/.github/workflows/cygwin-51x.yml
+++ b/.github/workflows/cygwin-51x.yml
@@ -1,10 +1,9 @@
 name: Cygwin 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-51x-32bit.yml
+++ b/.github/workflows/linux-51x-32bit.yml
@@ -1,10 +1,9 @@
 name: 32bit 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-51x-bytecode.yml
+++ b/.github/workflows/linux-51x-bytecode.yml
@@ -1,10 +1,9 @@
 name: Bytecode 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-51x-debug.yml
+++ b/.github/workflows/linux-51x-debug.yml
@@ -1,10 +1,9 @@
 name: Linux 5.1 debug
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-51x-fp.yml
+++ b/.github/workflows/linux-51x-fp.yml
@@ -1,10 +1,9 @@
 name: FP 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-51x.yml
+++ b/.github/workflows/linux-51x.yml
@@ -1,10 +1,9 @@
 name: Linux 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macosx-51x.yml
+++ b/.github/workflows/macosx-51x.yml
@@ -1,10 +1,9 @@
 name: macOS 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mingw-51x-bytecode.yml
+++ b/.github/workflows/mingw-51x-bytecode.yml
@@ -1,10 +1,9 @@
 name: MinGW bytecode 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mingw-51x.yml
+++ b/.github/workflows/mingw-51x.yml
@@ -1,10 +1,9 @@
 name: MinGW 5.1
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
5.1.1 has been released for some time now, meaning there is less reason to continuously test it.
This PR therefore retires the 5.1.x workflows to run once per week, like the 5.0.0 workflows.