### PR TITLE
Move 520-workflows on GitHub actions to 5.2.0~beta1

### DIFF
--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -12,6 +12,6 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~alpha1+options+win
+      compiler: ocaml-variants.5.2.0~beta1+options+win
       cygwin: true
       timeout: 360

--- a/.github/workflows/linux-520-32bit.yml
+++ b/.github/workflows/linux-520-32bit.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~alpha1+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.2.0~beta1+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-520-bytecode.yml
+++ b/.github/workflows/linux-520-bytecode.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~alpha1+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.2.0~beta1+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~alpha1'
+      compiler: 'ocaml-base-compiler.5.2.0~beta1'
       dune_profile: 'debug-runtime'
       runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-520-fp.yml
+++ b/.github/workflows/linux-520-fp.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~alpha1+options,ocaml-option-fp'
+      compiler: 'ocaml-variants.5.2.0~beta1+options,ocaml-option-fp'
       timeout: 240

--- a/.github/workflows/linux-520.yml
+++ b/.github/workflows/linux-520.yml
@@ -11,4 +11,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~alpha1'
+      compiler: 'ocaml-base-compiler.5.2.0~beta1'

--- a/.github/workflows/macosx-520.yml
+++ b/.github/workflows/macosx-520.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~alpha1'
+      compiler: 'ocaml-base-compiler.5.2.0~beta1'
       runs_on: 'macos-latest'

--- a/.github/workflows/mingw-520-bytecode.yml
+++ b/.github/workflows/mingw-520-bytecode.yml
@@ -12,5 +12,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~alpha1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.2.0~beta1+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/mingw-520.yml
+++ b/.github/workflows/mingw-520.yml
@@ -12,5 +12,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~alpha1+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.2.0~beta1+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
This moves our 520-workflows to target the freshly released `5.2.0~beta1`