### PR TITLE
Reduce Cygwin timeouts to 240m like the remaining workflows

### DIFF
--- a/.github/workflows/cygwin-51x.yml
+++ b/.github/workflows/cygwin-51x.yml
@@ -13,4 +13,4 @@ jobs:
       runs_on: windows-latest
       compiler: ocaml-variants.5.1.1+options+win
       cygwin: true
-      timeout: 360
+      timeout: 240

--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -14,4 +14,4 @@ jobs:
       runs_on: windows-latest
       compiler: ocaml-variants.5.2.0~beta1+options+win
       cygwin: true
-      timeout: 360
+      timeout: 240

--- a/.github/workflows/cygwin-530-trunk.yml
+++ b/.github/workflows/cygwin-530-trunk.yml
@@ -15,4 +15,4 @@ jobs:
       compiler: ocaml.5.3.0
       cygwin: true
       compiler_git_ref: refs/heads/trunk
-      timeout: 360
+      timeout: 240


### PR DESCRIPTION
Earlier, we struggled with Cygwin workflows being slow.
This was a necessity in #305 and #313 as the Cygwin port initially was too slow to complete within the 6h timeout!
In #420 we then merged them into a single workflow, like the remaining targets.
This is running well, but still suffers from timeouts due to #307, adding 2 hours compared to the MinGW counterparts.
This PR therefore reduced the Cygwin workflow timeouts to 240m like the remaining workflows.