### PR TITLE
Reenable Bigarray STM tests

### DIFF
--- a/src/bigarray/dune
+++ b/src/bigarray/dune
@@ -5,8 +5,7 @@
  (modules stm_tests)
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
- ; (action (run %{test} --verbose))
- (action (echo "Skipping src/bigarray/%{test} from the test suite\n\n"))
+ (action (run %{test} --verbose))
 )
 
 (test

--- a/src/bigarray/lin_tests.ml
+++ b/src/bigarray/lin_tests.ml
@@ -29,6 +29,5 @@ module BA1T = Lin_domain.Make(BA1Conf)
 
 let _ =
   QCheck_base_runner.run_tests_main [
-    BA1T.neg_lin_test ~count:5000 ~name:"Lin Bigarray.Array1 (of ints) test with Domain";
     BA1T.stress_test  ~count:1000 ~name:"Lin Bigarray.Array1 stress test with Domain";
   ]

--- a/src/bigarray/stm_tests.ml
+++ b/src/bigarray/stm_tests.ml
@@ -69,8 +69,10 @@ struct
     (* | Sub (i,l)    -> Res (result (array char) exn, protect (Array.sub a i) l) *)
     | Fill n -> Res (result unit exn, protect (Array1.fill ba) n)
 
+  let word_size_in_bytes = Sys.word_size / 8
+
   let postcond n (s:int list) res = match n, res with
-    | Size_in_bytes, Res ((Int,_),r) -> r = 8 * (List.length s)
+    | Size_in_bytes, Res ((Int,_),r) -> r = word_size_in_bytes * (List.length s)
     | Get i, Res ((Result (Int,Exn),_), r) ->
       if i < 0 || i >= List.length s
       then r = Error (Invalid_argument "index out of bounds")

--- a/src/bigarray/stm_tests.ml
+++ b/src/bigarray/stm_tests.ml
@@ -57,10 +57,9 @@ struct
     Array1.fill ba 0 ;
     ba
 
-  let cleanup _   = ()
+  let cleanup _ = ()
 
-  let precond n _s = match n with
-    | _ -> true
+  let precond _n _s = true
 
   let run n ba = match n with
     | Size_in_bytes -> Res (STM.int, Array1.size_in_bytes ba)
@@ -71,15 +70,15 @@ struct
     | Fill n -> Res (result unit exn, protect (Array1.fill ba) n)
 
   let postcond n (s:int list) res = match n, res with
-    | Size_in_bytes, Res ((Int,_),i) -> i = 8 * (List.length s)
+    | Size_in_bytes, Res ((Int,_),r) -> r = 8 * (List.length s)
     | Get i, Res ((Result (Int,Exn),_), r) ->
       if i < 0 || i >= List.length s
-        then r = Error (Invalid_argument "index out of bounds")
-        else r = Ok (List.nth s i)
+      then r = Error (Invalid_argument "index out of bounds")
+      else r = Ok (List.nth s i)
     | Set (i,_), Res ((Result (Unit,Exn),_), r) ->
       if i < 0 || i >= List.length s
-        then r = Error (Invalid_argument "index out of bounds")
-        else r = Ok ()
+      then r = Error (Invalid_argument "index out of bounds")
+      else r = Ok ()
     (* STM don't support bigarray type for the moment*)
     (* | Sub (i,l), Res ((Result (Array Char,Exn),_), r) ->
       if i < 0 || l < 0 || i+l > List.length s

--- a/src/bigarray/stm_tests.ml
+++ b/src/bigarray/stm_tests.ml
@@ -93,8 +93,7 @@ end
 module BigArraySTM_seq = STM_sequential.Make(BAConf)
 module BigArraySTM_dom = STM_domain.Make(BAConf)
 ;;
-QCheck_base_runner.run_tests_main
-  (let count = 1000 in
-   [BigArraySTM_seq.agree_test         ~count ~name:"STM BigArray test sequential";
-    BigArraySTM_dom.neg_agree_test_par ~count ~name:"STM BigArray test parallel"
-])
+QCheck_base_runner.run_tests_main [
+  BigArraySTM_seq.agree_test         ~count:1000 ~name:"STM BigArray test sequential";
+  BigArraySTM_dom.neg_agree_test_par ~count:5000 ~name:"STM BigArray test parallel"
+]


### PR DESCRIPTION
This PR reenables the `Bigarray` `STM` tests, the idea being that a model-based `STM` test is stricter than a `Lin` one.

A bit of background:
- `Lin` tests of `Bigarray` were added in #121
- `STM` tests of `Bigarray` were added in #125
- The `STM` `Bigarray` tests were disabled in #250 (by mistake AFAICS)
- This PR leaves stress tests of `Bigarray` using the `Lin` spec #443