### PR TITLE
Temporarily disable Dynlink tests under Windows

### DIFF
--- a/src/dynlink/lin_tests.ml
+++ b/src/dynlink/lin_tests.ml
@@ -31,10 +31,11 @@ end
 module DynT = Lin_domain.Make(DynConf)
 
 let _ =
-  let ts = [DynT.stress_test ~count:1000 ~name:"Lin Dynlink stress test with Domain"] in
-  let ts =
-    if Sys.win32 then
-      (Printf.printf "negative Lin Dynlink test with Domain disabled under Windows\n\n%!"; ts)
-    else
-      (DynT.neg_lin_test ~count:100 ~name:"negative Lin Dynlink test with Domain")::ts in
-  QCheck_base_runner.run_tests_main ts
+  if Sys.win32
+  then
+    Printf.printf "Lin Dynlink tests disabled under Windows\n\n%!"
+  else
+    QCheck_base_runner.run_tests_main [
+      DynT.neg_lin_test ~count:100  ~name:"negative Lin Dynlink test with Domain";
+      DynT.stress_test  ~count:1000 ~name:"Lin Dynlink stress test with Domain";
+    ]


### PR DESCRIPTION
This PR temporarily disables the `Dynlink` tests under Windows as
- a fix is in the pipeline
- they are adding noise to every run

Once merged, I'll open a "reminder-PR" to reenable both of them under Windows.