### PR TITLE
Increment count for STM int64 ref test with Thread

### DIFF
--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -9,5 +9,5 @@ then
 else
 QCheck_base_runner.run_tests_main
   [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
-   RT_int64.neg_agree_test_conc ~count:2500 ~name:"STM int64 ref test with Thread";
+   RT_int64.neg_agree_test_conc ~count:5000 ~name:"STM int64 ref test with Thread";
   ]


### PR DESCRIPTION
This failed to trigger a counterexample on macos-arm64-5.2 within 2500 iterations on the merge of #454 to `main`.