### PR TITLE
Reuse domains rather than spawning them for each parallel test

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,8 @@ sequential and parallel tests against a declarative model.")
  (depends
   (ocaml (>= 4.12))
   (qcheck-core           (>= "0.20"))
-  (qcheck-multicoretests-util (= :version))))
+  (qcheck-multicoretests-util (= :version))
+  (domainslib (>= 0.5.1))))
 
 (package
  (name qcheck-lin)
@@ -47,7 +48,8 @@ and explained by some sequential interleaving.")
  (depends
   (ocaml (>= 4.12))
   (qcheck-core           (>= "0.20"))
-  (qcheck-multicoretests-util (= :version))))
+  (qcheck-multicoretests-util (= :version))
+  (domainslib (>= 0.5.1))))
 
 (package
  (name qcheck-multicoretests-util)

--- a/lib/STM_domain.ml
+++ b/lib/STM_domain.ml
@@ -1,5 +1,7 @@
 open STM
 
+module T = Domainslib.Task
+
 module Make (Spec: Spec) = struct
 
   open Util
@@ -22,14 +24,14 @@ module Make (Spec: Spec) = struct
     let res_arr = Array.map (fun c -> Domain.cpu_relax(); Spec.run c sut) cs_arr in
     List.combine cs (Array.to_list res_arr)
 
-  let agree_prop_par (seq_pref,cmds1,cmds2) =
+  let agree_prop_par ~pool (seq_pref,cmds1,cmds2) =
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
     let wait = Atomic.make true in
-    let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; try Ok (interp_sut_res sut cmds1) with exn -> Error exn) in
-    let dom2 = Domain.spawn (fun () -> Atomic.set wait false; try Ok (interp_sut_res sut cmds2) with exn -> Error exn) in
-    let obs1 = Domain.join dom1 in
-    let obs2 = Domain.join dom2 in
+    let dom1 = T.async pool (fun () -> while Atomic.get wait do () done; try Ok (interp_sut_res sut cmds1) with exn -> Error exn) in
+    let dom2 = T.async pool (fun () -> Atomic.set wait false; try Ok (interp_sut_res sut cmds2) with exn -> Error exn) in
+    let obs1 = T.await pool dom1 in
+    let obs2 = T.await pool dom2 in
     let ()   = Spec.cleanup sut in
     let obs1 = match obs1 with Ok v -> v | Error exn -> raise exn in
     let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
@@ -39,20 +41,20 @@ module Make (Spec: Spec) = struct
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,obs1,obs2)
 
-  let agree_prop_par_asym (seq_pref, cmds1, cmds2) =
+  let agree_prop_par_asym ~pool (seq_pref, cmds1, cmds2) =
     let sut = Spec.init_sut () in
     let pref_obs = interp_sut_res sut seq_pref in
     let wait = Atomic.make 2 in
     let child_dom =
-      Domain.spawn (fun () ->
+      T.async pool (fun () ->
           Atomic.decr wait;
-          while Atomic.get wait <> 0 do Domain.cpu_relax() done;
+          while Atomic.get wait <> 0 do () done;
           try Ok (interp_sut_res sut cmds2) with exn -> Error exn)
     in
     Atomic.decr wait;
-    while Atomic.get wait <> 0 do Domain.cpu_relax() done;
+    while Atomic.get wait <> 0 do () done;
     let parent_obs = try Ok (interp_sut_res sut cmds1) with exn -> Error exn in
-    let child_obs = Domain.join child_dom in
+    let child_obs = T.await pool child_dom in
     let () = Spec.cleanup sut in
     let parent_obs = match parent_obs with Ok v -> v | Error exn -> raise exn in
     let child_obs = match child_obs with Ok v -> v | Error exn -> raise exn in
@@ -62,7 +64,7 @@ module Make (Spec: Spec) = struct
            (fun (c,r) -> Printf.sprintf "%s : %s" (Spec.show_cmd c) (show_res r))
            (pref_obs,parent_obs,child_obs)
 
-  let agree_test_par ~count ~name =
+  let agree_test_par ~pool ~count ~name =
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
@@ -70,9 +72,9 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
-         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
+         repeat rep_count (agree_prop_par ~pool) triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
-  let neg_agree_test_par ~count ~name =
+  let neg_agree_test_par ~pool ~count ~name =
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
@@ -80,9 +82,9 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
-         repeat rep_count agree_prop_par triple) (* 25 times each, then 25 * 10 times when shrinking *)
+         repeat rep_count (agree_prop_par ~pool) triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
-  let agree_test_par_asym ~count ~name =
+  let agree_test_par_asym ~pool ~count ~name =
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
@@ -90,9 +92,9 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
-         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
+         repeat rep_count (agree_prop_par_asym ~pool) triple) (* 25 times each, then 25 * 10 times when shrinking *)
 
-  let neg_agree_test_par_asym ~count ~name =
+  let neg_agree_test_par_asym ~pool ~count ~name =
     let rep_count = 25 in
     let seq_len,par_len = 20,12 in
     let max_gen = 3*count in (* precond filtering may require extra generation: max. 3*count though *)
@@ -100,5 +102,5 @@ module Make (Spec: Spec) = struct
       (arb_cmds_triple seq_len par_len)
       (fun triple ->
          assume (all_interleavings_ok triple);
-         repeat rep_count agree_prop_par_asym triple) (* 25 times each, then 25 * 10 times when shrinking *)
+         repeat rep_count (agree_prop_par_asym ~pool) triple) (* 25 times each, then 25 * 10 times when shrinking *)
 end

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -40,7 +40,7 @@ module Make : functor (Spec : STM.Spec) ->
     (** [interp_sut_res sut cs] interprets the commands [cs] over the system {!Spec.sut}
         and returns the list of corresponding {!Spec.cmd} and result pairs. *)
 
-    val agree_prop_par : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
+    val agree_prop_par : pool:Domainslib.Task.pool -> Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
     (** Parallel agreement property based on {!Stdlib.Domain}.
         [agree_prop_par (seq_pref, tl1, tl2)] first interprets [seq_pref]
         and then spawns two parallel, symmetric domains interpreting [tl1] and
@@ -49,7 +49,7 @@ module Make : functor (Spec : STM.Spec) ->
         @return [true] if there exists a sequential interleaving of the results
         which agrees with a model interpretation. *)
 
-    val agree_prop_par_asym : Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
+    val agree_prop_par_asym : pool:Domainslib.Task.pool -> Spec.cmd list * Spec.cmd list * Spec.cmd list -> bool
     (** Asymmetric parallel agreement property based on {!Stdlib.Domain}.
         [agree_prop_par_asym (seq_pref, tl1, tl2)] first interprets [seq_pref],
         and then interprets [tl1] while a spawned domain interprets [tl2]
@@ -58,21 +58,21 @@ module Make : functor (Spec : STM.Spec) ->
         @return [true] if there exists a sequential interleaving of the results
         which agrees with a model interpretation. *)
 
-    val agree_test_par : count:int -> name:string -> QCheck.Test.t
+    val agree_test_par : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
     (** Parallel agreement test based on {!Stdlib.Domain} which combines [repeat] and [~retries].
         Accepts two labeled parameters:
         [count] is the number of test iterations and [name] is the printed test name. *)
 
-    val neg_agree_test_par : count:int -> name:string -> QCheck.Test.t
+    val neg_agree_test_par : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
     (** A negative parallel agreement test (for convenience). Accepts two labeled parameters:
         [count] is the number of test iterations and [name] is the printed test name. *)
 
-    val agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
+    val agree_test_par_asym : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
     (** Asymmetric parallel agreement test based on {!Stdlib.Domain} and {!agree_prop_par_asym}
         which combines [repeat] and [~retries]. Accepts two labeled parameters:
         [count] is the number of test iterations and [name] is the printed test name. *)
 
-    val neg_agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
+    val neg_agree_test_par_asym : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
     (** A negative asymmetric parallel agreement test (for convenience).
         Accepts two labeled parameters:
         [count] is the number of test iterations and [name] is the printed test name. *)

--- a/lib/dune
+++ b/lib/dune
@@ -15,7 +15,7 @@
  (public_name qcheck-stm.domain)
  (modules STM_domain)
  (enabled_if (>= %{ocaml_version} 5))
- (libraries qcheck-core qcheck-stm.stm))
+ (libraries qcheck-core qcheck-stm.stm domainslib))
 
 (library
  (name STM_thread)

--- a/lib/dune
+++ b/lib/dune
@@ -34,7 +34,7 @@
  (public_name qcheck-lin.domain)
  (modules lin_domain)
  (enabled_if (>= %{ocaml_version} 5))
- (libraries qcheck-core qcheck-core.runner qcheck-multicoretests-util qcheck-lin.lin))
+ (libraries qcheck-core qcheck-core.runner qcheck-multicoretests-util qcheck-lin.lin domainslib))
 
 (library
  (name lin_effect)

--- a/lib/lin_domain.ml
+++ b/lib/lin_domain.ml
@@ -10,22 +10,22 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
     let res_arr = Array.map (fun c -> Domain.cpu_relax(); Spec.run c sut) cs_arr in
     List.combine cs (Array.to_list res_arr)
 
-  let run_parallel (seq_pref,cmds1,cmds2) =
+  let run_parallel ~pool (seq_pref,cmds1,cmds2) =
     let sut = Spec.init () in
     let pref_obs = interp sut seq_pref in
     let wait = Atomic.make true in
-    let dom1 = Domain.spawn (fun () -> while Atomic.get wait do Domain.cpu_relax() done; try Ok (interp sut cmds1) with exn -> Error exn) in
-    let dom2 = Domain.spawn (fun () -> Atomic.set wait false; try Ok (interp sut cmds2) with exn -> Error exn) in
-    let obs1 = Domain.join dom1 in
-    let obs2 = Domain.join dom2 in
+    let dom1 = Domainslib.Task.async pool (fun () -> while Atomic.get wait do () done; try Ok (interp sut cmds1) with exn -> Error exn) in
+    let dom2 = Domainslib.Task.async pool (fun () -> Atomic.set wait false; try Ok (interp sut cmds2) with exn -> Error exn) in
+    let obs1 = Domainslib.Task.await pool dom1 in
+    let obs2 = Domainslib.Task.await pool dom2 in
     Spec.cleanup sut ;
     let obs1 = match obs1 with Ok v -> v | Error exn -> raise exn in
     let obs2 = match obs2 with Ok v -> v | Error exn -> raise exn in
     (pref_obs,obs1,obs2)
 
   (* Linearization property based on [Domain] and an Atomic flag *)
-  let lin_prop (seq_pref,cmds1,cmds2) =
-    let pref_obs,obs1,obs2 = run_parallel (seq_pref,cmds1,cmds2) in
+  let lin_prop ~pool (seq_pref,cmds1,cmds2) =
+    let pref_obs,obs1,obs2 = run_parallel ~pool (seq_pref,cmds1,cmds2) in
     let seq_sut = Spec.init () in
     check_seq_cons pref_obs obs1 obs2 seq_sut []
       || QCheck.Test.fail_reportf "  Results incompatible with sequential execution\n\n%s"
@@ -34,18 +34,18 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
               (pref_obs,obs1,obs2)
 
   (* "Don't crash under parallel usage" property *)
-  let stress_prop (seq_pref,cmds1,cmds2) =
-    let _ = run_parallel (seq_pref,cmds1,cmds2) in
+  let stress_prop ~pool (seq_pref,cmds1,cmds2) =
+    let _ = run_parallel ~pool (seq_pref,cmds1,cmds2) in
     true
 
-  let lin_test ~count ~name =
-    M.lin_test ~rep_count:50 ~count ~retries:3 ~name ~lin_prop:lin_prop
+  let lin_test ~pool ~count ~name =
+    M.lin_test ~rep_count:50 ~count ~retries:3 ~name ~lin_prop:(lin_prop ~pool)
 
-  let neg_lin_test ~count ~name =
-    neg_lin_test ~rep_count:50 ~count ~retries:3 ~name ~lin_prop:lin_prop
+  let neg_lin_test ~pool ~count ~name =
+    neg_lin_test ~rep_count:50 ~count ~retries:3 ~name ~lin_prop:(lin_prop ~pool)
 
-  let stress_test ~count ~name =
-    M.lin_test ~rep_count:25 ~count ~retries:5 ~name ~lin_prop:stress_prop
+  let stress_test ~pool ~count ~name =
+    M.lin_test ~rep_count:25 ~count ~retries:5 ~name ~lin_prop:(stress_prop ~pool)
 end
 
 module Make (Spec : Spec) = Make_internal(MakeCmd(Spec))

--- a/lib/lin_domain.mli
+++ b/lib/lin_domain.mli
@@ -2,32 +2,40 @@ open Lin
 
 (** functor to build an internal module representing parallel tests *)
 module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
-  val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
-  val lin_prop : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
-  val stress_prop : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
-  val lin_test : count:int -> name:string -> QCheck.Test.t
-  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
-  val stress_test : count:int -> name:string -> QCheck.Test.t
+  val arb_cmds_triple
+    :  int
+    -> int
+    -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
+
+  val lin_prop : pool:Domainslib.Task.pool -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
+
+  val stress_prop : pool:Domainslib.Task.pool -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
+
+  val lin_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
+
+  val neg_lin_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
+
+  val stress_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
 end
   [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
 (** functor to build a module for parallel testing *)
 module Make (Spec : Spec) : sig
-  val lin_test : count:int -> name:string -> QCheck.Test.t
+  val lin_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
   (** [lin_test ~count:c ~name:n] builds a parallel test with the name [n] that
       iterates [c] times. The test fails if one of the generated programs is not
       sequentially consistent. In that case it fails, and prints a reduced
       counter example.
   *)
 
-  val neg_lin_test : count:int -> name:string -> QCheck.Test.t
+  val neg_lin_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
   (** [neg_lin_test ~count:c ~name:n] builds a negative parallel test with the
       name [n] that iterates [c] times. The test fails if no counter example is
       found, and succeeds if a counter example is indeed found, and prints it
       afterwards.
   *)
 
-  val stress_test : count:int -> name:string -> QCheck.Test.t
+  val stress_test : pool:Domainslib.Task.pool -> count:int -> name:string -> QCheck.Test.t
   (** [stress_test ~count:c ~name:n] builds a parallel test with the name
       [n] that iterates [c] times. The test fails if an unexpected exception is
       raised underway. It is intended as a stress test and does not perform an

--- a/qcheck-lin.opam
+++ b/qcheck-lin.opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "qcheck-core" {>= "0.20"}
   "qcheck-multicoretests-util" {= version}
+  "domainslib" {>= "0.5.1"}
   "odoc" {with-doc}
 ]
 depopts: ["base-domains"]

--- a/qcheck-stm.opam
+++ b/qcheck-stm.opam
@@ -25,6 +25,7 @@ depends: [
   "ocaml" {>= "4.12"}
   "qcheck-core" {>= "0.20"}
   "qcheck-multicoretests-util" {= version}
+  "domainslib" {>= "0.5.1"}
   "odoc" {with-doc}
 ]
 depopts: ["base-domains"]

--- a/src/array/dune
+++ b/src/array/dune
@@ -22,6 +22,6 @@
  (name lin_tests)
  (modules lin_tests)
  (package multicoretests)
- (libraries qcheck-lin.domain)
+ (libraries qcheck-lin.domain domainslib)
  (action (run %{test} --verbose))
 )

--- a/src/array/lin_internal_tests.ml
+++ b/src/array/lin_internal_tests.ml
@@ -117,6 +117,11 @@ end
 
 module AT_domain = Lin_domain.Make_internal(AConf) [@alert "-internal"]
 ;;
+let () =
+  let module T = Domainslib.Task in
+  let pool = T.setup_pool ~num_domains:2 () in
+  T.run pool (fun () ->
 QCheck_base_runner.run_tests_main [
-  AT_domain.neg_lin_test ~count:1000 ~name:"Lin.Internal Array test with Domain";
-]
+  AT_domain.neg_lin_test ~pool ~count:1000 ~name:"Lin.Internal Array test with Domain";
+]) |> ignore;
+  T.teardown_pool pool

--- a/src/array/lin_tests.ml
+++ b/src/array/lin_tests.ml
@@ -28,7 +28,12 @@ end
 
 module AT_domain = Lin_domain.Make(AConf)
 ;;
+let () =
+  let module T = Domainslib.Task in
+  let pool = T.setup_pool ~num_domains:2 () in
+  T.run pool (fun () ->
 QCheck_base_runner.run_tests_main [
-  AT_domain.neg_lin_test ~count:1000 ~name:"Lin Array test with Domain";
-  AT_domain.stress_test  ~count:1000 ~name:"Lin Array stress test with Domain";
-]
+  AT_domain.neg_lin_test ~pool ~count:1000 ~name:"Lin Array test with Domain";
+  AT_domain.stress_test  ~pool ~count:1000 ~name:"Lin Array stress test with Domain";
+]) |> ignore;
+  T.teardown_pool pool

--- a/src/array/stm_tests.ml
+++ b/src/array/stm_tests.ml
@@ -162,8 +162,14 @@ end
 module ArraySTM_seq = STM_sequential.Make(AConf)
 module ArraySTM_dom = STM_domain.Make(AConf)
 ;;
+let () =
+  let module T = Domainslib.Task in
+  let pool = T.setup_pool ~num_domains:2 () in
+  T.run pool (fun () ->
 QCheck_base_runner.run_tests_main
   (let count = 1000 in
    [ArraySTM_seq.agree_test         ~count ~name:"STM Array test sequential";
-    ArraySTM_dom.neg_agree_test_par ~count ~name:"STM Array test parallel" (* this test is expected to fail *)
-])
+    ArraySTM_dom.neg_agree_test_par ~pool ~count ~name:"STM Array test parallel"; (* this test is expected to fail *)
+    (*ArraySTM_dom.stress_test_par ~pool ~count ~name:"STM Array stress test" (* Test for absence of crashes *)*)
+ ])) |> ignore;
+  T.teardown_pool pool


### PR DESCRIPTION
Given that domains are costly to spawn and join, and parallel tests in multicoretests do it many thousands of times, I wanted to look at it more closely. A quick perf profile on `src/array/lin_tests.ml` shows that more than 50 % of the time is spent in `Domain.spawn`. I wanted to try spawning domains only at the start of the test sequence and reusing them. Then I realised that this is exactly what Domainslib provides with domain pools!

This proof of concept PR simply replaces `Domain.spawn`  with `Domainslib.Task.async` and `Domain.join` with `Domainslib.Task.await`. The approach implies to setup a domain pool and pass it to the tests. I have edited `src/array/{lin,stm}_tests.ml` to reflect this.

The results are rather encouraging: `src/array/lin_tests.ml` is cut down from about 4.5 s to 0.3 s! (With extremely far off statistical outliers due to bad luck in interleaving search.) However, this is a favourable case as the test’s commands are very cheap to run. The same comparison on my extensive Dynarray STM parallel test gives 24 s vs 12 s for the version with domain reuse, so merely a 2x speedup.

If depending on Domainslib is an issue, the mechanism can be reimplemented using atomics, mutexes and condition variables easily enough. (A reimplementation would likely squeeze some more performance out by not requiring a work-stealing queue.)

It looks like about 20 % of the time is now taken by `Sys.cpu_relax`, so further improvement may be possible still.