### PR TITLE
Add explicit macOS Intel+ARM64 runners

### DIFF
--- a/.github/workflows/macosx-arm64-500.yml
+++ b/.github/workflows/macosx-arm64-500.yml
@@ -1,0 +1,13 @@
+name: macOS-ARM64 5.0.0
+
+on:
+  schedule:
+    # Every Sunday morning, at 1:11 UTC
+    - cron: '11 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: 'macos-14'

--- a/.github/workflows/macosx-arm64-51x.yml
+++ b/.github/workflows/macosx-arm64-51x.yml
@@ -1,0 +1,14 @@
+name: macOS-ARM64 5.1
+
+on:
+  schedule:
+    # Every Sunday morning, at 2:22 UTC
+    - cron: '22 2 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-base-compiler.5.1.1'
+      runs_on: 'macos-14'

--- a/.github/workflows/macosx-arm64-520.yml
+++ b/.github/workflows/macosx-arm64-520.yml
@@ -1,0 +1,15 @@
+name: macOS-ARM64 5.2
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      runs_on: 'macos-14'

--- a/.github/workflows/macosx-arm64-530-trunk.yml
+++ b/.github/workflows/macosx-arm64-530-trunk.yml
@@ -1,0 +1,16 @@
+name: macOS-ARM64 trunk
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      runs_on: 'macos-14'

--- a/.github/workflows/macosx-intel-500.yml
+++ b/.github/workflows/macosx-intel-500.yml
@@ -1,4 +1,4 @@
-name: macOS 5.0.0
+name: macOS-intel 5.0.0
 
 on:
   schedule:
@@ -10,4 +10,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      runs_on: 'macos-latest'
+      runs_on: 'macos-13'

--- a/.github/workflows/macosx-intel-51x.yml
+++ b/.github/workflows/macosx-intel-51x.yml
@@ -1,4 +1,4 @@
-name: macOS 5.1
+name: macOS-intel 5.1
 
 on:
   schedule:
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-base-compiler.5.1.1'
-      runs_on: 'macos-latest'
+      runs_on: 'macos-13'

--- a/.github/workflows/macosx-intel-520.yml
+++ b/.github/workflows/macosx-intel-520.yml
@@ -1,4 +1,4 @@
-name: macOS trunk
+name: macOS-intel 5.2
 
 on:
   pull_request:
@@ -11,6 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.3.0+trunk'
-      compiler_git_ref: refs/heads/trunk
-      runs_on: 'macos-latest'
+      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      runs_on: 'macos-13'

--- a/.github/workflows/macosx-intel-530-trunk.yml
+++ b/.github/workflows/macosx-intel-530-trunk.yml
@@ -1,4 +1,4 @@
-name: macOS 5.2
+name: macOS-intel trunk
 
 on:
   pull_request:
@@ -11,5 +11,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~beta2'
-      runs_on: 'macos-latest'
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      runs_on: 'macos-13'

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -24,7 +24,8 @@ jobs:
           - 4.14.x
           - 5.0.0
           - 5.1.0
-          - ocaml-variants.5.2.0+trunk
+          - 5.2.0
+          - ocaml-variants.5.3.0+trunk
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multicore tests
 [![OPAM installation](https://github.com/ocaml-multicore/multicoretests/actions/workflows/opam.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/opam.yml)
 
 [![Linux 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml)
-[![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-500.yml)
+[![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml)
 [![Linux 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml)
 [![Linux 5.0.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml)
 [![Linux 32-bit 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml)
@@ -12,7 +12,7 @@ Multicore tests
 [![MinGW 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-500-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-500-bytecode.yml)
 
 [![Linux 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml)
-[![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-51x.yml)
+[![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml)
 [![Linux 5.1.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml)
 [![Linux 5.1.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml)
 [![Linux 32-bit 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml)
@@ -22,7 +22,7 @@ Multicore tests
 [![Cygwin 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-51x.yml)
 
 [![Linux 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml)
-[![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-520.yml)
+[![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml)
 [![Linux 5.2.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml)
 [![Linux 5.2.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml)
 [![Linux 32-bit 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml)
@@ -32,7 +32,7 @@ Multicore tests
 [![Cygwin 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520.yml)
 
 [![Linux 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml)
-[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-530-trunk.yml)
+[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml)
 [![Linux 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml)
 [![Linux 5.3.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml)
 [![Linux 32-bit 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Multicore tests
 [![OPAM installation](https://github.com/ocaml-multicore/multicoretests/actions/workflows/opam.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/opam.yml)
 
 [![Linux 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml)
-[![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml)
-[![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml)
+[![macOS-Intel 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml)
+[![macOS-ARM64 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml)
 [![Linux 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml)
 [![Linux 5.0.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml)
 [![Linux 32-bit 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml)
@@ -13,8 +13,8 @@ Multicore tests
 [![MinGW 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-500-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-500-bytecode.yml)
 
 [![Linux 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml)
-[![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml)
-[![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml)
+[![macOS-Intel 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml)
+[![macOS-ARM64 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml)
 [![Linux 5.1.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml)
 [![Linux 5.1.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml)
 [![Linux 32-bit 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml)
@@ -24,8 +24,8 @@ Multicore tests
 [![Cygwin 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-51x.yml)
 
 [![Linux 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml)
-[![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml)
-[![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml)
+[![macOS-Intel 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml)
+[![macOS-ARM64 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml)
 [![Linux 5.2.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml)
 [![Linux 5.2.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml)
 [![Linux 32-bit 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml)
@@ -35,8 +35,8 @@ Multicore tests
 [![Cygwin 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-520.yml)
 
 [![Linux 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml)
-[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml)
-[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml)
+[![macOS-Intel 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml)
+[![macOS-ARM64 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml)
 [![Linux 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml)
 [![Linux 5.3.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml)
 [![Linux 32-bit 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Multicore tests
 
 [![Linux 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500.yml)
 [![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-500.yml)
+[![MacOSX 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-500.yml)
 [![Linux 5.0.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-bytecode.yml)
 [![Linux 5.0.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-debug.yml)
 [![Linux 32-bit 5.0.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-500-32bit.yml)
@@ -13,6 +14,7 @@ Multicore tests
 
 [![Linux 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x.yml)
 [![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-51x.yml)
+[![MacOSX 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-51x.yml)
 [![Linux 5.1.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-bytecode.yml)
 [![Linux 5.1.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-debug.yml)
 [![Linux 32-bit 5.1.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-51x-32bit.yml)
@@ -23,6 +25,7 @@ Multicore tests
 
 [![Linux 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520.yml)
 [![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-520.yml)
+[![MacOSX 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-520.yml)
 [![Linux 5.2.0-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-bytecode.yml)
 [![Linux 5.2.0-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-debug.yml)
 [![Linux 32-bit 5.2.0](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-520-32bit.yml)
@@ -33,6 +36,7 @@ Multicore tests
 
 [![Linux 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk.yml)
 [![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-530-trunk.yml)
+[![MacOSX 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-530-trunk.yml)
 [![Linux 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-bytecode.yml)
 [![Linux 5.3.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-debug.yml)
 [![Linux 32-bit 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-530-trunk-32bit.yml)

--- a/src/sys/stm_tests.ml
+++ b/src/sys/stm_tests.ml
@@ -330,5 +330,5 @@ QCheck_base_runner.run_tests_main [
     Sys_seq.agree_test              ~count:1000 ~name:"STM Sys test sequential";
     if Sys.unix && uname_os () = Some "Linux"
     then Sys_dom.agree_test_par     ~count:200  ~name:"STM Sys test parallel"
-    else Sys_dom.neg_agree_test_par ~count:1000 ~name:"STM Sys test parallel"
+    else Sys_dom.neg_agree_test_par ~count:2500 ~name:"STM Sys test parallel"
   ]

--- a/src/sys/stm_tests.ml
+++ b/src/sys/stm_tests.ml
@@ -322,15 +322,13 @@ let run_cmd cmd =
 
 let uname_os () = run_cmd "uname -s"
 
-let arch () = run_cmd "opam var arch"
-
 module Sys_seq = STM_sequential.Make(SConf)
 module Sys_dom = STM_domain.Make(SConf)
 
 ;;
 QCheck_base_runner.run_tests_main [
     Sys_seq.agree_test              ~count:1000 ~name:"STM Sys test sequential";
-    if Sys.unix && (uname_os () = Some "Linux" || arch () = Some "arm64")
+    if Sys.unix && uname_os () = Some "Linux"
     then Sys_dom.agree_test_par     ~count:200  ~name:"STM Sys test parallel"
     else Sys_dom.neg_agree_test_par ~count:1000 ~name:"STM Sys test parallel"
   ]


### PR DESCRIPTION
For quite some time, GitHub actions only supported macOS on Intel hardware.
That has changed recently: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

Interestingly, we have used `macos-latest` which then changed hardware underneath our feet.
I noticed, because the once-per-week 5.0.0 and 5.1.1 workflows started finding an `STM` `Sys` parallel counterexample relatively consistently.
(details below)

This PR thus adds explicit macOS Intel (macos-13) and ARM64 (macos-14) workflows, thus collecting them both in the same GitHub actions CI "backend". I'll write a separate PR to remove the macOS ARM64 runners from multicoretests-ci.


Examples of the two latest runs:

https://github.com/ocaml-multicore/multicoretests/actions/runs/9048073196/job/24860738931
```
version: 5.0.0
architecture: arm64
system: macosx

random seed: 139266489
generated error fail pass / total     time test name

[ ]    0    0    0    0 / 1000     0.0s STM Sys test sequential
[ ]    0    0    0    0 / 1000     0.0s STM Sys test sequential (generating)
[✓] 1000    0    0 1000 / 1000     4.6s STM Sys test sequential

[ ]    0    0    0    0 /  200     0.0s STM Sys test parallel
[✗]  143    0    1  142 /  200    42.2s STM Sys test parallel

--- Failure --------------------------------------------------------------------

Test STM Sys test parallel failed (23 shrink steps):

                             |           
                     Mkdir ([], "ddd")   
                             |           
                  .---------------------.
                  |                     |           
          Rmdir ([], "ddd")     Rmdir ([], "ddd")   
```

https://github.com/ocaml-multicore/multicoretests/actions/runs/9048277550/job/24861161644
```
version: 5.1.1
architecture: arm64
system: macosx

random seed: 222784250
generated error fail pass / total     time test name

[ ]    0    0    0    0 / 1000     0.0s STM Sys test sequential
[ ]    0    0    0    0 / 1000     0.0s STM Sys test sequential (generating)
[✓] 1000    0    0 1000 / 1000     3.6s STM Sys test sequential

[ ]    0    0    0    0 /  200     0.0s STM Sys test parallel
[✗]   44    0    1   43 /  200    31.8s STM Sys test parallel

--- Failure --------------------------------------------------------------------

Test STM Sys test parallel failed (26 shrink steps):

                             |           
                     Mkdir ([], "ddd")   
                             |           
                  .---------------------.
                  |                     |           
          Rmdir ([], "ddd")     Rmdir ([], "ddd")
```