### PR TITLE
Move GA workflows from 5.2.0~beta2 to 5.2.0 release

### DIFF
--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -12,6 +12,6 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~beta2+options+win
+      compiler: ocaml-variants.5.2.0+options+win
       cygwin: true
       timeout: 240

--- a/.github/workflows/linux-520-32bit.yml
+++ b/.github/workflows/linux-520-32bit.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~beta2+options,ocaml-option-32bit'
+      compiler: 'ocaml-variants.5.2.0+options,ocaml-option-32bit'
       timeout: 240

--- a/.github/workflows/linux-520-bytecode.yml
+++ b/.github/workflows/linux-520-bytecode.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~beta2+options,ocaml-option-bytecode-only'
+      compiler: 'ocaml-variants.5.2.0+options,ocaml-option-bytecode-only'
       timeout: 240

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      compiler: 'ocaml-base-compiler.5.2.0'
       dune_profile: 'debug-runtime'
       runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-520-fp.yml
+++ b/.github/workflows/linux-520-fp.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.2.0~beta2+options,ocaml-option-fp'
+      compiler: 'ocaml-variants.5.2.0+options,ocaml-option-fp'
       timeout: 240

--- a/.github/workflows/linux-520.yml
+++ b/.github/workflows/linux-520.yml
@@ -11,4 +11,4 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      compiler: 'ocaml-base-compiler.5.2.0'

--- a/.github/workflows/macosx-arm64-520.yml
+++ b/.github/workflows/macosx-arm64-520.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      compiler: 'ocaml-base-compiler.5.2.0'
       runs_on: 'macos-14'

--- a/.github/workflows/macosx-intel-520.yml
+++ b/.github/workflows/macosx-intel-520.yml
@@ -11,5 +11,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-base-compiler.5.2.0~beta2'
+      compiler: 'ocaml-base-compiler.5.2.0'
       runs_on: 'macos-13'

--- a/.github/workflows/mingw-520-bytecode.yml
+++ b/.github/workflows/mingw-520-bytecode.yml
@@ -12,5 +12,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~beta2+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler: ocaml-variants.5.2.0+options+win,ocaml-option-mingw,ocaml-option-bytecode-only
       timeout: 240

--- a/.github/workflows/mingw-520.yml
+++ b/.github/workflows/mingw-520.yml
@@ -12,5 +12,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml-variants.5.2.0~beta2+options+win,ocaml-option-mingw
+      compiler: ocaml-variants.5.2.0+options+win,ocaml-option-mingw
       timeout: 240


### PR DESCRIPTION
Following https://github.com/shym/custom-opam-repository/pull/12 this PR moves the GitHub Actions workflows from `5.2.0~beta2` to the `5.2.0` release.