### PR TITLE
Trigger a 5.2 run every Monday morning

### DIFF
--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -1,6 +1,9 @@
 name: Cygwin 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-32bit.yml
+++ b/.github/workflows/linux-520-32bit.yml
@@ -1,6 +1,9 @@
 name: 32bit 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-bytecode.yml
+++ b/.github/workflows/linux-520-bytecode.yml
@@ -1,6 +1,9 @@
 name: Bytecode 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -1,6 +1,9 @@
 name: Linux 5.2 debug
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-fp.yml
+++ b/.github/workflows/linux-520-fp.yml
@@ -1,6 +1,9 @@
 name: FP 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520.yml
+++ b/.github/workflows/linux-520.yml
@@ -1,6 +1,9 @@
 name: Linux 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-arm64-520.yml
+++ b/.github/workflows/macosx-arm64-520.yml
@@ -1,6 +1,9 @@
 name: macOS-ARM64 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-intel-520.yml
+++ b/.github/workflows/macosx-intel-520.yml
@@ -1,6 +1,9 @@
 name: macOS-intel 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-520-bytecode.yml
+++ b/.github/workflows/mingw-520-bytecode.yml
@@ -1,6 +1,9 @@
 name: MinGW bytecode 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-520.yml
+++ b/.github/workflows/mingw-520.yml
@@ -1,6 +1,9 @@
 name: MinGW 5.2
 
 on:
+  schedule:
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:


### PR DESCRIPTION
#461 added a weekly `trunk` CI run.

To better understand
- whether some issues show up on 5.2 but not `trunk`, e.g, #446 and
- how the testsuite outcome works across time

this PR adds corresponding scheduled 5.2 CI runs every Monday morning.