### PR TITLE
Add 5.4.0+trunk workflows

### DIFF
--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -2,8 +2,8 @@ name: Cygwin 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/cygwin-530-trunk.yml
+++ b/.github/workflows/cygwin-530-trunk.yml
@@ -2,8 +2,8 @@ name: Cygwin 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/cygwin-540-trunk.yml
+++ b/.github/workflows/cygwin-540-trunk.yml
@@ -2,8 +2,8 @@ name: Cygwin trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/cygwin-540-trunk.yml
+++ b/.github/workflows/cygwin-540-trunk.yml
@@ -1,4 +1,4 @@
-name: Cygwin 5.3
+name: Cygwin trunk
 
 on:
   schedule:
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       runs_on: windows-latest
-      compiler: ocaml.5.3.0
+      compiler: ocaml.5.4.0
       cygwin: true
-      compiler_git_ref: refs/heads/5.3
+      compiler_git_ref: refs/heads/trunk
       timeout: 240

--- a/.github/workflows/linux-520-32bit.yml
+++ b/.github/workflows/linux-520-32bit.yml
@@ -2,8 +2,8 @@ name: 32bit 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-bytecode.yml
+++ b/.github/workflows/linux-520-bytecode.yml
@@ -2,8 +2,8 @@ name: Bytecode 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -2,8 +2,8 @@ name: Linux 5.2 debug
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520-fp.yml
+++ b/.github/workflows/linux-520-fp.yml
@@ -2,8 +2,8 @@ name: FP 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-520.yml
+++ b/.github/workflows/linux-520.yml
@@ -2,8 +2,8 @@ name: Linux 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-530-trunk-32bit.yml
+++ b/.github/workflows/linux-530-trunk-32bit.yml
@@ -2,8 +2,8 @@ name: 32bit 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-530-trunk-bytecode.yml
+++ b/.github/workflows/linux-530-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: Bytecode 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-530-trunk-bytecode.yml
+++ b/.github/workflows/linux-530-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: Bytecode trunk
+name: Bytecode 5.3
 
 on:
   schedule:
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-bytecode-only'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       timeout: 240

--- a/.github/workflows/linux-530-trunk-debug.yml
+++ b/.github/workflows/linux-530-trunk-debug.yml
@@ -2,8 +2,8 @@ name: Linux 5.3 debug
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-530-trunk-debug.yml
+++ b/.github/workflows/linux-530-trunk-debug.yml
@@ -1,4 +1,4 @@
-name: Linux trunk debug
+name: Linux 5.3 debug
 
 on:
   schedule:
@@ -15,7 +15,7 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       dune_profile: 'debug-runtime'
       runparam: 's=4096,v=0,V=1'
       timeout: 240

--- a/.github/workflows/linux-530-trunk-fp.yml
+++ b/.github/workflows/linux-530-trunk-fp.yml
@@ -2,8 +2,8 @@ name: FP 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-530-trunk-fp.yml
+++ b/.github/workflows/linux-530-trunk-fp.yml
@@ -1,4 +1,4 @@
-name: FP trunk
+name: FP 5.3
 
 on:
   schedule:
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-fp'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       timeout: 240

--- a/.github/workflows/linux-530-trunk.yml
+++ b/.github/workflows/linux-530-trunk.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: Linux 5.3
 
 on:
   schedule:
@@ -15,4 +15,4 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3

--- a/.github/workflows/linux-530-trunk.yml
+++ b/.github/workflows/linux-530-trunk.yml
@@ -2,8 +2,8 @@ name: Linux 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk-32bit.yml
+++ b/.github/workflows/linux-540-trunk-32bit.yml
@@ -2,8 +2,8 @@ name: 32bit trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk-32bit.yml
+++ b/.github/workflows/linux-540-trunk-32bit.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: 32bit trunk
 
 on:
   schedule:
@@ -14,5 +14,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.4.0+trunk'
+      compiler: 'ocaml-variants.5.4.0+trunk,ocaml-option-32bit'
       compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-540-trunk-bytecode.yml
+++ b/.github/workflows/linux-540-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: Bytecode trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk-bytecode.yml
+++ b/.github/workflows/linux-540-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: Bytecode trunk
 
 on:
   schedule:
@@ -14,5 +14,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.4.0+trunk'
+      compiler: 'ocaml-variants.5.4.0+trunk,ocaml-option-bytecode-only'
       compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-540-trunk-debug.yml
+++ b/.github/workflows/linux-540-trunk-debug.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: Linux trunk debug
 
 on:
   schedule:
@@ -16,3 +16,6 @@ jobs:
     with:
       compiler: 'ocaml-variants.5.4.0+trunk'
       compiler_git_ref: refs/heads/trunk
+      dune_profile: 'debug-runtime'
+      runparam: 's=4096,v=0,V=1'
+      timeout: 240

--- a/.github/workflows/linux-540-trunk-debug.yml
+++ b/.github/workflows/linux-540-trunk-debug.yml
@@ -2,8 +2,8 @@ name: Linux trunk debug
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk-fp.yml
+++ b/.github/workflows/linux-540-trunk-fp.yml
@@ -1,4 +1,4 @@
-name: Linux trunk
+name: FP trunk
 
 on:
   schedule:
@@ -14,5 +14,6 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.4.0+trunk'
+      compiler: 'ocaml-variants.5.4.0+trunk,ocaml-option-fp'
       compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/linux-540-trunk-fp.yml
+++ b/.github/workflows/linux-540-trunk-fp.yml
@@ -2,8 +2,8 @@ name: FP trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk.yml
+++ b/.github/workflows/linux-540-trunk.yml
@@ -2,8 +2,8 @@ name: Linux trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/linux-540-trunk.yml
+++ b/.github/workflows/linux-540-trunk.yml
@@ -1,4 +1,4 @@
-name: 32bit 5.3
+name: Linux trunk
 
 on:
   schedule:
@@ -14,6 +14,5 @@ jobs:
   build:
     uses: ./.github/workflows/common.yml
     with:
-      compiler: 'ocaml-variants.5.3.0+trunk,ocaml-option-32bit'
-      compiler_git_ref: refs/heads/5.3
-      timeout: 240
+      compiler: 'ocaml-variants.5.3.0+trunk'
+      compiler_git_ref: refs/heads/trunk

--- a/.github/workflows/macosx-arm64-520.yml
+++ b/.github/workflows/macosx-arm64-520.yml
@@ -2,8 +2,8 @@ name: macOS-ARM64 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-arm64-530-trunk.yml
+++ b/.github/workflows/macosx-arm64-530-trunk.yml
@@ -2,8 +2,8 @@ name: macOS-ARM64 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-arm64-530-trunk.yml
+++ b/.github/workflows/macosx-arm64-530-trunk.yml
@@ -1,4 +1,4 @@
-name: macOS-ARM64 trunk
+name: macOS-ARM64 5.3
 
 on:
   schedule:
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       runs_on: 'macos-14'

--- a/.github/workflows/macosx-arm64-540-trunk.yml
+++ b/.github/workflows/macosx-arm64-540-trunk.yml
@@ -1,0 +1,19 @@
+name: macOS-ARM64 trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.4.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      runs_on: 'macos-14'

--- a/.github/workflows/macosx-arm64-540-trunk.yml
+++ b/.github/workflows/macosx-arm64-540-trunk.yml
@@ -2,8 +2,8 @@ name: macOS-ARM64 trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-intel-520.yml
+++ b/.github/workflows/macosx-intel-520.yml
@@ -2,8 +2,8 @@ name: macOS-intel 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-intel-530-trunk.yml
+++ b/.github/workflows/macosx-intel-530-trunk.yml
@@ -1,4 +1,4 @@
-name: macOS-intel trunk
+name: macOS-intel 5.3
 
 on:
   schedule:
@@ -15,5 +15,5 @@ jobs:
     uses: ./.github/workflows/common.yml
     with:
       compiler: 'ocaml-variants.5.3.0+trunk'
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       runs_on: 'macos-13'

--- a/.github/workflows/macosx-intel-530-trunk.yml
+++ b/.github/workflows/macosx-intel-530-trunk.yml
@@ -2,8 +2,8 @@ name: macOS-intel 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-intel-540-trunk.yml
+++ b/.github/workflows/macosx-intel-540-trunk.yml
@@ -2,8 +2,8 @@ name: macOS-intel trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/macosx-intel-540-trunk.yml
+++ b/.github/workflows/macosx-intel-540-trunk.yml
@@ -1,0 +1,19 @@
+name: macOS-intel trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      compiler: 'ocaml-variants.5.4.0+trunk'
+      compiler_git_ref: refs/heads/trunk
+      runs_on: 'macos-13'

--- a/.github/workflows/mingw-520-bytecode.yml
+++ b/.github/workflows/mingw-520-bytecode.yml
@@ -2,8 +2,8 @@ name: MinGW bytecode 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-520.yml
+++ b/.github/workflows/mingw-520.yml
@@ -2,8 +2,8 @@ name: MinGW 5.2
 
 on:
   schedule:
-    # Every Monday morning, at 2:22 UTC
-    - cron: '22 2 * * 1'
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-530-trunk-bytecode.yml
+++ b/.github/workflows/mingw-530-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: MinGW bytecode 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-530-trunk-bytecode.yml
+++ b/.github/workflows/mingw-530-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: MinGW bytecode trunk
+name: MinGW bytecode 5.3
 
 on:
   schedule:
@@ -16,5 +16,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.3.0,ocaml-option-mingw,ocaml-option-bytecode-only
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       timeout: 240

--- a/.github/workflows/mingw-530-trunk.yml
+++ b/.github/workflows/mingw-530-trunk.yml
@@ -2,8 +2,8 @@ name: MinGW 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-530-trunk.yml
+++ b/.github/workflows/mingw-530-trunk.yml
@@ -1,4 +1,4 @@
-name: MinGW trunk
+name: MinGW 5.3
 
 on:
   schedule:
@@ -16,5 +16,5 @@ jobs:
     with:
       runs_on: windows-latest
       compiler: ocaml.5.3.0,ocaml-option-mingw
-      compiler_git_ref: refs/heads/trunk
+      compiler_git_ref: refs/heads/5.3
       timeout: 240

--- a/.github/workflows/mingw-540-trunk-bytecode.yml
+++ b/.github/workflows/mingw-540-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: MinGW bytecode trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-540-trunk-bytecode.yml
+++ b/.github/workflows/mingw-540-trunk-bytecode.yml
@@ -1,0 +1,20 @@
+name: MinGW bytecode trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.4.0,ocaml-option-mingw,ocaml-option-bytecode-only
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/mingw-540-trunk.yml
+++ b/.github/workflows/mingw-540-trunk.yml
@@ -2,8 +2,8 @@ name: MinGW trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/mingw-540-trunk.yml
+++ b/.github/workflows/mingw-540-trunk.yml
@@ -1,0 +1,20 @@
+name: MinGW trunk
+
+on:
+  schedule:
+    # Every Monday morning, at 1:11 UTC
+    - cron: '11 1 * * 1'
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/common.yml
+    with:
+      runs_on: windows-latest
+      compiler: ocaml.5.4.0,ocaml-option-mingw
+      compiler_git_ref: refs/heads/trunk
+      timeout: 240

--- a/.github/workflows/msvc-530-trunk-bytecode.yml
+++ b/.github/workflows/msvc-530-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: MSVC bytecode 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/msvc-530-trunk-bytecode.yml
+++ b/.github/workflows/msvc-530-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: MSVC bytecode trunk
+name: MSVC bytecode 5.3
 
 on:
   schedule:
@@ -15,3 +15,4 @@ jobs:
     uses: ./.github/workflows/msvc-common.yml
     with:
       bytecodeonly: true
+      compiler_ref: '5.3'

--- a/.github/workflows/msvc-530-trunk.yml
+++ b/.github/workflows/msvc-530-trunk.yml
@@ -2,8 +2,8 @@ name: MSVC 5.3
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 2:22 UTC
+    - cron: '22 2 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/msvc-540-trunk-bytecode.yml
+++ b/.github/workflows/msvc-540-trunk-bytecode.yml
@@ -2,8 +2,8 @@ name: MSVC bytecode trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/msvc-540-trunk-bytecode.yml
+++ b/.github/workflows/msvc-540-trunk-bytecode.yml
@@ -1,4 +1,4 @@
-name: MSVC 5.3
+name: MSVC bytecode trunk
 
 on:
   schedule:
@@ -14,4 +14,5 @@ jobs:
   build:
     uses: ./.github/workflows/msvc-common.yml
     with:
-      compiler_ref: '5.3'
+      bytecodeonly: true
+      compiler_ref: 'trunk'

--- a/.github/workflows/msvc-540-trunk.yml
+++ b/.github/workflows/msvc-540-trunk.yml
@@ -2,8 +2,8 @@ name: MSVC trunk
 
 on:
   schedule:
-    # Every Monday morning, at 1:11 UTC
-    - cron: '11 1 * * 1'
+    # Every Monday morning, at 3:33 UTC
+    - cron: '33 3 * * 1'
   pull_request:
   push:
     branches:

--- a/.github/workflows/msvc-540-trunk.yml
+++ b/.github/workflows/msvc-540-trunk.yml
@@ -1,4 +1,4 @@
-name: MSVC 5.3
+name: MSVC trunk
 
 on:
   schedule:
@@ -14,4 +14,4 @@ jobs:
   build:
     uses: ./.github/workflows/msvc-common.yml
     with:
-      compiler_ref: '5.3'
+      compiler_ref: 'trunk'

--- a/.github/workflows/msvc-common.yml
+++ b/.github/workflows/msvc-common.yml
@@ -14,6 +14,13 @@ on:
         description: 'dune alias that should be built in the main step'
         type: string
         default: 'runtest'
+      compiler_ref:
+        description: |
+          Git ref (such as "trunk") of the compiler.
+          This ref will be used to checkout the relevant "ocaml/ocaml" github branch.
+        type: string
+        default: ''
+
 
 jobs:
   build:
@@ -34,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/ocaml
-          ref: trunk
+          ref: ${{ inputs.compiler_ref }}
           path: ocaml
           submodules: true
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Multicore tests
 [![MSVC 5.3.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-530-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-530-trunk.yml)
 [![MSVC 5.3.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-530-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-530-trunk-bytecode.yml)
 
+[![Linux 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk.yml)
+[![macOS-Intel 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-intel-540-trunk.yml)
+[![macOS-ARM64 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/macosx-arm64-540-trunk.yml)
+[![Linux 5.4.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-bytecode.yml)
+[![Linux 5.4.0+trunk-debug](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-debug.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-debug.yml)
+[![Linux 32-bit 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-32bit.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-32bit.yml)
+[![Linux FP 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-fp.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/linux-540-trunk-fp.yml)
+[![MinGW 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-540-trunk.yml)
+[![MinGW 5.4.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-540-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/mingw-540-trunk-bytecode.yml)
+[![Cygwin 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/cygwin-540-trunk.yml)
+[![MSVC 5.4.0+trunk](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-540-trunk.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-540-trunk.yml)
+[![MSVC 5.4.0+trunk-bytecode](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-540-trunk-bytecode.yml/badge.svg)](https://github.com/ocaml-multicore/multicoretests/actions/workflows/msvc-540-trunk-bytecode.yml)
+
 Property-based tests of (parts of) the OCaml multicore compiler and run time.
 
 This project contains


### PR DESCRIPTION
This PR adds 5.4.0+trunk workflows following the 5.3 branching and the renaming of trunk to `5.4`.
It builds on the opam files added and adjusted in the custom repo PR https://github.com/shym/custom-opam-repository/pull/13 to update the MinGW and Cygwin workflows.

The MSVC workflows were hardcoded to `trunk` in msvc-common.yml and hence needed `input` adjustment.

While at it, I rescheduled some of the weekly CI runs, so that with this PR they run in order (pardon the OCD): :grin: 
- 5.2.0 runs Mondays 1:11
- 5.3.0 runs Mondays 2:22
- 5.4.0 runs Mondays 3:33

In another PR I plan to reduce the 5.2.0 to just the weekly ones, as 5.3.0 and `trunk` will be the relevant versions going forward.