### PR TITLE
Reduce `STM.cmds_gen` list size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
   requiring an interleaving search.
 - #462: Add `STM_domain.stress_test_par`, similar to `Lin_domain.stress_test`
   for STM models.
+- #472: Switch `arb_cmds` to use an exponential distribution with a
+  mean of 10, avoiding lists of up to 10000 cmds in `STM_sequential`
+  (reported by @nikolaushuber).
 
 ## 0.3
 

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -159,8 +159,14 @@ struct
 
     let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
 
+    let exp_dist_gen =
+      let mean = 10. in
+      let skew = 0.75 in (* to avoid too many empty cmd lists *)
+      let unit_gen = Gen.float_bound_inclusive 1.0 in
+      Gen.map (fun p -> int_of_float (-. (mean *. (log p)) +. skew)) unit_gen
+
     let arb_cmds s =
-      let cmds_gen = Gen.sized (gen_cmds Spec.arb_cmd s) in
+      let cmds_gen = gen_cmds_size Spec.arb_cmd s exp_dist_gen in
       let shrinker = shrink_list ?shrink:(Spec.arb_cmd s).shrink in (* pass opt. elem. shrinker *)
       let ac = QCheck.make ~shrink:(Shrink.filter (cmds_ok Spec.init_state) shrinker) cmds_gen in
       (match (Spec.arb_cmd s).print with

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -157,6 +157,8 @@ struct
       | None -> () (* no elem. shrinker provided *)
       | Some shrink -> Shrink.list_elems shrink l yield
 
+    let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
+
     let arb_cmds s =
       let cmds_gen = Gen.sized (gen_cmds Spec.arb_cmd s) in
       let shrinker = shrink_list ?shrink:(Spec.arb_cmd s).shrink in (* pass opt. elem. shrinker *)
@@ -236,8 +238,6 @@ struct
           ||
           (let b2 = Spec.postcond c2 s res2 in
            b2 && check_obs pref cs1 cs2' (Spec.next_state c2 s))
-
-    let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
 
     (* Shrinks a single cmd, starting in the given state *)
     let shrink_cmd arb cmd state =

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -159,14 +159,17 @@ struct
 
     let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
 
-    let exp_dist_gen =
-      let mean = 10. in
-      let skew = 0.75 in (* to avoid too many empty cmd lists *)
+    let exp_dist_gen mean =
       let unit_gen = Gen.float_bound_inclusive 1.0 in
-      Gen.map (fun p -> int_of_float (-. (mean *. (log p)) +. skew)) unit_gen
+      Gen.map (fun p -> -. mean *. (log p)) unit_gen
+
+    let cmd_list_size_dist mean =
+      let skew = 0.75 in (* to avoid too many empty cmd lists *)
+      Gen.map (fun p -> int_of_float (p +. skew)) (exp_dist_gen mean)
 
     let arb_cmds s =
-      let cmds_gen = gen_cmds_size Spec.arb_cmd s exp_dist_gen in
+      let mean = 10. in (* generate on average ~10 cmds, ignoring skew *)
+      let cmds_gen = gen_cmds_size Spec.arb_cmd s (cmd_list_size_dist mean) in
       let shrinker = shrink_list ?shrink:(Spec.arb_cmd s).shrink in (* pass opt. elem. shrinker *)
       let ac = QCheck.make ~shrink:(Shrink.filter (cmds_ok Spec.init_state) shrinker) cmds_gen in
       (match (Spec.arb_cmd s).print with

--- a/test/mutable_set_v4.expected.32
+++ b/test/mutable_set_v4.expected.32
@@ -2,10 +2,10 @@
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 
-Test STM sequential tests failed (13 shrink steps):
+Test STM sequential tests failed (9 shrink steps):
 
-   Add (-605797133)
-   Remove (-605797133)
+   Add (-923247292)
+   Remove (-923247292)
    Cardinal
 
 
@@ -15,8 +15,8 @@ Messages for test STM sequential tests:
 
   Results incompatible with model
 
-   Add (-605797133) : ()
-   Remove (-605797133) : Some (-605797133)
+   Add (-923247292) : ()
+   Remove (-923247292) : Some (-923247292)
    Cardinal : 1
 ================================================================================
 [31;1mfailure[0m (1 tests failed, 0 tests errored, ran 1 tests)

--- a/test/mutable_set_v4.expected.64
+++ b/test/mutable_set_v4.expected.64
@@ -2,7 +2,7 @@
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 
-Test STM sequential tests failed (13 shrink steps):
+Test STM sequential tests failed (11 shrink steps):
 
    Add (-3576245632788335623)
    Remove (-3576245632788335623)

--- a/test/mutable_set_v5.expected.32
+++ b/test/mutable_set_v5.expected.32
@@ -4,8 +4,8 @@
 
 Test STM sequential tests failed (2 shrink steps):
 
-   Add (-942638288)
-   Remove (-942638288)
+   Add (-286715106)
+   Remove (-286715106)
    Cardinal
 
 
@@ -15,8 +15,8 @@ Messages for test STM sequential tests:
 
   Results incompatible with model
 
-   Add (-942638288) : ()
-   Remove (-942638288) : Some (-942638288)
+   Add (-286715106) : ()
+   Remove (-286715106) : Some (-286715106)
    Cardinal : 1
 ================================================================================
 [31;1mfailure[0m (1 tests failed, 0 tests errored, ran 1 tests)

--- a/test/mutable_set_v5.expected.64
+++ b/test/mutable_set_v5.expected.64
@@ -2,10 +2,10 @@
 
 --- [31;1mFailure[0m --------------------------------------------------------------------
 
-Test STM sequential tests failed (15 shrink steps):
+Test STM sequential tests failed (6 shrink steps):
 
-   Add (-3922091896265746428)
-   Remove (-3922091896265746428)
+   Add 3036269937054427589
+   Remove 3036269937054427589
    Cardinal
 
 
@@ -15,8 +15,8 @@ Messages for test STM sequential tests:
 
   Results incompatible with model
 
-   Add (-3922091896265746428) : ()
-   Remove (-3922091896265746428) : Some (-3922091896265746428)
+   Add 3036269937054427589 : ()
+   Remove 3036269937054427589 : Some (3036269937054427589)
    Cardinal : 1
 ================================================================================
 [31;1mfailure[0m (1 tests failed, 0 tests errored, ran 1 tests)


### PR DESCRIPTION
`STM_sequential` uses `Gen.sized` to generate `cmd list`s, which means the output size depends on `Gen.nat`, which may output lists of up size 10.000 with a 5% chance.

Here's are some quick stats to illustrate, here on the Domain.DLS STM test:
```
multicoretests-latest$ dune exec src/domain/stm_tests_dls.exe -- -v
random seed: 245423950
generated error fail pass / total     time test name
[✓] 1000    0    0 1000 / 1000     0.5s STM Domain.DLS test sequential

+++ Stats for STM Domain.DLS test sequential ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats cmd length:
  num: 1000, avg: 364.61, stddev: 1267.28, median 9, min 0, max 9737
     0.. 486: #######################################################         856
   487.. 973: ######                                                           94
   974..1460:                                                                   4
  1461..1947:                                                                   2
  1948..2434:                                                                   5
  2435..2921:                                                                   4
  2922..3408:                                                                   2
  3409..3895:                                                                   2
  3896..4382:                                                                   2
  4383..4869:                                                                   4
  4870..5356:                                                                   2
  5357..5843:                                                                   6
  5844..6330:                                                                   0
  6331..6817:                                                                   2
  6818..7304:                                                                   3
  7305..7791:                                                                   2
  7792..8278:                                                                   0
  8279..8765:                                                                   1
  8766..9252:                                                                   4
  9253..9739:                                                                   5
================================================================================
success (ran 1 tests)
```

A cmd list of length 9737 is excessive - and now hurts client users of the library, such as Ortac's QCheck-STM plugin!

This PR therefore proposes to replace the distribution with an [exponential distribution]( https://en.wikipedia.org/wiki/Exponential_distribution) instead.

For a start I've gone with a mean of 10, and added a bit of skew to avoid generating too many empty `cmd lists`, which should be less interesting in a state-machine setup. The resulting distribution looks as follows (now with count raised to 10000, and a 230/10000 ~ 2.3% chance of generating empty cmd lists which seems reasonable):
```
multicoretests-latest$ dune exec src/domain/stm_tests_dls.exe -- -v
random seed: 7625658
generated error  fail  pass / total     time test name
[✓] 10000     0     0 10000 / 10000    15.3s STM Domain.DLS test sequential

+++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Collect results for test STM Domain.DLS test sequential:

not mt: 9770 cases
empty : 230 cases

+++ Stats for STM Domain.DLS test sequential ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats cmd length:
  num: 10000, avg: 10.27, stddev: 9.95, median 7, min 0, max 79
   0.. 3: #######################################################        2749
   4.. 7: ################################################               2417
   8..11: ###############################                                1568
  12..15: #####################                                          1095
  16..19: ##############                                                  706
  20..23: #########                                                       453
  24..27: ######                                                          314
  28..31: ####                                                            248
  32..35: ##                                                              147
  36..39: ##                                                              116
  40..43: #                                                                62
  44..47:                                                                  39
  48..51:                                                                  24
  52..55:                                                                  28
  56..59:                                                                  14
  60..63:                                                                   9
  64..67:                                                                   4
  68..71:                                                                   3
  72..75:                                                                   2
  76..79:                                                                   2
================================================================================
success (ran 1 tests)
```

I'm curious to see how this fares on the CI.

Shoutout to @nikolaushuber for reporting this.

Note to self: might warrant a changelog entry.