### PR TITLE
Small cleanups to ease upstreaming

### DIFF
--- a/.github/runner.sh
+++ b/.github/runner.sh
@@ -203,7 +203,7 @@ case "$1" in
     ;;
   internaltests)
     cd "$MULTICORETESTSDIR"
-    dune runtest -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice test/
+    dune build @internaltests -j1 --no-buffer --display=quiet --cache=disabled --error-reporting=twice
     ;;
   *)
     fatal "Unknown command '$1'"

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -36,7 +36,7 @@ on:
       dune_alias:
         description: 'dune alias that should be built in the main step'
         type: string
-        default: 'runtest'
+        default: 'testsuite'
       compiler_repository:
         description: 'Repository from which to fetch the compiler'
         type: string

--- a/.github/workflows/linux-500-debug.yml
+++ b/.github/workflows/linux-500-debug.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       compiler_ref: refs/tags/5.0.0
       dune_profile: 'debug-runtime'
-      runparam: 's=4096,v=0,V=1'
+      runparam: 's=4096,V=1'
       timeout: 240

--- a/.github/workflows/linux-51x-debug.yml
+++ b/.github/workflows/linux-51x-debug.yml
@@ -12,5 +12,5 @@ jobs:
     with:
       compiler_ref: refs/tags/5.1.1
       dune_profile: 'debug-runtime'
-      runparam: 's=4096,v=0,V=1'
+      runparam: 's=4096,V=1'
       timeout: 240

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       compiler_ref: refs/tags/5.2.0
       dune_profile: 'debug-runtime'
-      runparam: 's=4096,v=0,V=1'
+      runparam: 's=4096,V=1'
       timeout: 240

--- a/.github/workflows/linux-530-trunk-debug.yml
+++ b/.github/workflows/linux-530-trunk-debug.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       compiler_ref: refs/heads/5.3
       dune_profile: 'debug-runtime'
-      runparam: 's=4096,v=0,V=1'
+      runparam: 's=4096,V=1'
       timeout: 240

--- a/.github/workflows/linux-540-trunk-debug.yml
+++ b/.github/workflows/linux-540-trunk-debug.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       compiler_ref: refs/heads/trunk
       dune_profile: 'debug-runtime'
-      runparam: 's=4096,v=0,V=1'
+      runparam: 's=4096,V=1'
       timeout: 240

--- a/dune
+++ b/dune
@@ -16,13 +16,27 @@
  (package multicoretests)
  (deps (alias src/default)))
 
+; The main test alias
+(alias
+ (name testsuite)
+ (package multicoretests)
+ (deps
+  (alias_rec src/runtest)))
+
+; The internal tests alias
+(alias
+ (name internaltests)
+ (package multicoretests)
+ (deps
+  (alias_rec test/runtest)))
+
 ; The aliases to control what is run in CI
 ; It can either be the full test suite, or focus on a single test
 (alias
  (name ci)
  (package multicoretests)
  (deps
-  (alias_rec %{env:DUNE_CI_ALIAS=runtest})))
+  (alias_rec %{env:DUNE_CI_ALIAS=testsuite})))
   ; (alias_rec focusedtest)))
 
 ; @focusedtest

--- a/dune
+++ b/dune
@@ -18,8 +18,6 @@
 
 ; The aliases to control what is run in CI
 ; It can either be the full test suite, or focus on a single test
-; Aliases ci1 and ci2 are useful to split the test suite into
-; subparts, for platforms such as Cygwin which are too slow
 (alias
  (name ci)
  (package multicoretests)

--- a/src/array/dune
+++ b/src/array/dune
@@ -15,7 +15,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/array/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test

--- a/src/atomic/dune
+++ b/src/atomic/dune
@@ -19,7 +19,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/atomic/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test

--- a/src/domain/dune
+++ b/src/domain/dune
@@ -24,7 +24,7 @@
  (package multicoretests)
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/domain/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test

--- a/src/hashtbl/dune
+++ b/src/hashtbl/dune
@@ -15,7 +15,7 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/hashtbl/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test

--- a/src/io/dune
+++ b/src/io/dune
@@ -7,7 +7,7 @@
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/io/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (library
@@ -33,7 +33,7 @@
  ;(flags (:standard -w -27))
  (libraries qcheck-lin.thread lin_tests_spec_io)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/io/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test

--- a/src/lazy/dune
+++ b/src/lazy/dune
@@ -14,7 +14,7 @@
  (package multicoretests)
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test
@@ -23,5 +23,5 @@
  (package multicoretests)
  (libraries qcheck-lin.domain)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/lazy/%{test} from the test suite\n\n"))
+ (action (progn))
 )

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -85,7 +85,7 @@
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.thread)
  ; (action (run %{test} --verbose))
- (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (test
@@ -106,7 +106,7 @@
  (flags (:standard -w -27))
  (libraries lin_internal_tests_common qcheck-lin.domain)
   ; (action (run %{test} --verbose))
- (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 
 (tests
@@ -125,5 +125,5 @@
  (flags (:standard -w -27))
  (libraries lin_internal_tests_common qcheck-lin.effect)
   ; (action (run ./%{deps} --verbose))
- (action (echo "Skipping src/neg_tests/%{test} from the test suite\n\n"))
+ (action (progn))
 )

--- a/src/queue/dune
+++ b/src/queue/dune
@@ -16,5 +16,5 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
  ;(action (run %{test} --verbose))
- (action (echo "Skipping src/queue/%{test} from the test suite\n\n"))
+ (action (progn))
 )

--- a/src/stack/dune
+++ b/src/stack/dune
@@ -16,6 +16,6 @@
  (flags (:standard -w -27))
  (libraries qcheck-lin.domain qcheck-lin.thread)
   ; (action (run %{test} --verbose))
- (action (echo "Skipping src/stack/%{test} from the test suite\n\n"))
+ (action (progn))
 )
 

--- a/test/dune
+++ b/test/dune
@@ -12,8 +12,9 @@
  (package qcheck-multicoretests-util)
  (libraries qcheck-multicoretests-util)
  (action
-  (setenv MCTUTILS_TRUNCATE ""
-   (run %{dep:util_pp.exe}))))
+  (setenv OCAMLRUNPARAM "%{env:OCAMLRUNPARAM=b},v=0"
+   (setenv MCTUTILS_TRUNCATE ""
+    (run %{dep:util_pp.exe})))))
 
 (rule
  (alias runtest)
@@ -21,8 +22,9 @@
  (action
   (progn
    (with-outputs-to util_pp_trunc150.output
-    (setenv MCTUTILS_TRUNCATE 150
-     (run %{dep:util_pp.exe})))
+    (setenv OCAMLRUNPARAM "%{env:OCAMLRUNPARAM=b},v=0"
+     (setenv MCTUTILS_TRUNCATE 150
+      (run %{dep:util_pp.exe}))))
    (diff? util_pp_trunc150.expected util_pp_trunc150.output))))
 
 (rule
@@ -31,8 +33,9 @@
  (action
   (progn
    (with-outputs-to util_pp_trunc79.output
-    (setenv MCTUTILS_TRUNCATE 79
-     (run %{dep:util_pp.exe})))
+    (setenv OCAMLRUNPARAM "%{env:OCAMLRUNPARAM=b},v=0"
+     (setenv MCTUTILS_TRUNCATE 79
+      (run %{dep:util_pp.exe}))))
    (diff? util_pp_trunc79.expected util_pp_trunc79.output))))
 
 (rule
@@ -41,8 +44,9 @@
  (action
   (progn
    (with-outputs-to util_pp_trunc5.output
-    (setenv MCTUTILS_TRUNCATE 5
-     (run %{dep:util_pp.exe})))
+    (setenv OCAMLRUNPARAM "%{env:OCAMLRUNPARAM=b},v=0"
+     (setenv MCTUTILS_TRUNCATE 5
+      (run %{dep:util_pp.exe}))))
    (diff? util_pp_trunc5.expected util_pp_trunc5.output))))
 
 (executable
@@ -91,7 +95,9 @@
  (package qcheck-stm)
  (libraries qcheck-stm.sequential threads.posix)
  (action
-  (with-accepted-exit-codes 1 (run ./%{test} --seed 229109553))))
+  (with-accepted-exit-codes 1
+   (setenv OCAMLRUNPARAM "%{env:OCAMLRUNPARAM=b},v=0"
+    (run ./%{test} --seed 229109553)))))
 
 (test
  (name stm_next_state_exc)


### PR DESCRIPTION
This PR brings a couple of small changes. In particular the main two commits are intended to make it a bit easier to upstream a workflow running the testsuite to the compiler:

- 665555c3 Define the `testsuite` and `internaltests` aliases
- 80ccd65f Silence all skipped tests

This will make it easier to run only the testsuite per se upstream, and to avoid the noise of the `Skipping ...` messages.

The other 3 commits are to use the new aliases in our CI, to let the `debug mode` message appear in debug runs and to remove an obsolete comment:

- 6662af3d Use the `testsuite` and `internaltests` aliases in CI
- cd5b374a Drop the v=0 parameter in CI debug runs
- fa43e243 Remove an obsolete comment