### PR TITLE
Disable 5.2.0 tests on PRs and pushes to main

### DIFF
--- a/.github/workflows/cygwin-520.yml
+++ b/.github/workflows/cygwin-520.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-520-32bit.yml
+++ b/.github/workflows/linux-520-32bit.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-520-bytecode.yml
+++ b/.github/workflows/linux-520-bytecode.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-520-debug.yml
+++ b/.github/workflows/linux-520-debug.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-520-fp.yml
+++ b/.github/workflows/linux-520-fp.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/linux-520.yml
+++ b/.github/workflows/linux-520.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macosx-arm64-520.yml
+++ b/.github/workflows/macosx-arm64-520.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/macosx-intel-520.yml
+++ b/.github/workflows/macosx-intel-520.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mingw-520-bytecode.yml
+++ b/.github/workflows/mingw-520-bytecode.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mingw-520.yml
+++ b/.github/workflows/mingw-520.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     # Every Monday morning, at 1:11 UTC
     - cron: '11 1 * * 1'
-  pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
With 5.3.0~beta1 coming out today, there is no need to continue testing 5.2 on PRs and pushes to main.
This PR thus reduces their runs to a cron job once a week.