### PR TITLE
Require qcheck-core.0.23

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: c-cube/qcheck
-          ref: v0.22
+          ref: v0.23
           path: multicoretests/qcheck
 
       - name: Pre-Setup

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next release
 
+- #491: Require `qcheck.0.23`, simplify show functions by utilizing it, and update
+  expect outputs accordingly
 - #486: Add `Util.Pp.pp_fun_` printer for generated `QCheck.fun_` functions
 
 ## 0.4

--- a/dune-project
+++ b/dune-project
@@ -17,7 +17,7 @@ the multicore run-time of OCaml 5.0.")
  (tags ("test" "test suite" "property" "qcheck" "quickcheck" "multicore" "non-determinism"))
  (depends
   base-domains
-  (qcheck-core          (>= "0.20"))
+  (qcheck-core          (>= "0.23"))
   (qcheck-lin           (= :version))
   (qcheck-stm           (= :version))))
 
@@ -31,7 +31,7 @@ sequential and parallel tests against a declarative model.")
  (depopts base-domains)
  (depends
   (ocaml (>= 4.12))
-  (qcheck-core           (>= "0.20"))
+  (qcheck-core           (>= "0.23"))
   (qcheck-multicoretests-util (= :version))))
 
 (package
@@ -46,7 +46,7 @@ and explained by some sequential interleaving.")
  (depopts base-domains)
  (depends
   (ocaml (>= 4.12))
-  (qcheck-core           (>= "0.20"))
+  (qcheck-core           (>= "0.23"))
   (qcheck-multicoretests-util (= :version))))
 
 (package
@@ -57,4 +57,4 @@ multicore programs.")
  (tags ("test" "property" "qcheck" "quickcheck" "multicore" "non-determinism"))
  (depends
   (ocaml (>= 4.12))
-  (qcheck-core           (>= "0.20"))))
+  (qcheck-core           (>= "0.23"))))

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -23,15 +23,15 @@ type _ ty +=
 
 type 'a ty_show = 'a ty * ('a -> string)
 
-let unit = (Unit, fun () -> "()")
-let bool = (Bool, string_of_bool)
-let char = (Char, fun c -> Printf.sprintf "%C" c)
-let int = (Int, string_of_int)
+let unit = (Unit, QCheck.Print.unit)
+let bool = (Bool, QCheck.Print.bool)
+let char = (Char, QCheck.Print.char)
+let int = (Int, QCheck.Print.int)
 let int32 = (Int32, Int32.to_string)
 let int64 = (Int64, Int64.to_string)
-let float = (Float, Float.to_string)
-let string = (String, fun s -> Printf.sprintf "%S" s)
-let bytes = (Bytes, fun b -> Printf.sprintf "%S" (Bytes.to_string b))
+let float = (Float, QCheck.Print.float)
+let string = (String, QCheck.Print.string)
+let bytes = (Bytes, QCheck.Print.bytes)
 let option spec =
   let (ty,show) = spec in
   (Option ty, QCheck.Print.option show)

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -155,16 +155,12 @@ let gen_deconstructible gen print eq = GenDeconstr (gen,print,eq)
 
 let qcheck_nat64_small = QCheck.(map Int64.of_int small_nat)
 
-let print_char c   = Printf.sprintf "%C" c
-let print_string s = Printf.sprintf "%S" s
-let print_bytes b  = print_string (Bytes.to_string b)
-
 let bytes_small_printable = QCheck.bytes_small_of QCheck.Gen.printable
 
 let unit =           GenDeconstr (QCheck.unit,           QCheck.Print.unit, (=))
 let bool =           GenDeconstr (QCheck.bool,           QCheck.Print.bool, (=))
-let char =           GenDeconstr (QCheck.char,           print_char,        (=))
-let char_printable = GenDeconstr (QCheck.printable_char, print_char,        (=))
+let char =           GenDeconstr (QCheck.char,           QCheck.Print.char, (=))
+let char_printable = GenDeconstr (QCheck.printable_char, QCheck.Print.char, (=))
 let nat_small =      GenDeconstr (QCheck.small_nat,      QCheck.Print.int,  (=))
 let int =            GenDeconstr (QCheck.int,            QCheck.Print.int,  (=))
 let int_small =      GenDeconstr (QCheck.small_int,      QCheck.Print.int,  (=))
@@ -173,13 +169,13 @@ let int_bound b =    GenDeconstr (QCheck.int_bound b,    QCheck.Print.int,  (=))
 let int32 =          GenDeconstr (QCheck.int32,          Int32.to_string,   Int32.equal)
 let int64 =          GenDeconstr (QCheck.int64,          Int64.to_string,   Int64.equal)
 let nat64_small =    GenDeconstr (qcheck_nat64_small,    Int64.to_string,   Int64.equal)
-let float =          GenDeconstr (QCheck.float,          Float.to_string,   Float.equal)
-let string =         GenDeconstr (QCheck.string,         print_string,      String.equal)
-let string_small =   GenDeconstr (QCheck.small_string,   print_string,      String.equal)
-let string_small_printable = GenDeconstr (QCheck.small_printable_string,   print_string,      String.equal)
-let bytes =          GenDeconstr (QCheck.bytes,          print_bytes,       Bytes.equal)
-let bytes_small =    GenDeconstr (QCheck.bytes_small,    print_bytes,       Bytes.equal)
-let bytes_small_printable = GenDeconstr (bytes_small_printable,   print_bytes,      Bytes.equal)
+let float =          GenDeconstr (QCheck.float,          QCheck.Print.float,  Float.equal)
+let string =         GenDeconstr (QCheck.string,         QCheck.Print.string, String.equal)
+let string_small =   GenDeconstr (QCheck.small_string,   QCheck.Print.string, String.equal)
+let string_small_printable = GenDeconstr (QCheck.small_printable_string, QCheck.Print.string, String.equal)
+let bytes =          GenDeconstr (QCheck.bytes,          QCheck.Print.bytes, Bytes.equal)
+let bytes_small =    GenDeconstr (QCheck.bytes_small,    QCheck.Print.bytes, Bytes.equal)
+let bytes_small_printable = GenDeconstr (bytes_small_printable, QCheck.Print.bytes, Bytes.equal)
 
 let option : type a c s. ?ratio:float -> (a, c, s, combinable) ty -> (a option, c, s, combinable) ty =
   fun ?ratio ty ->

--- a/multicoretests.opam
+++ b/multicoretests.opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
   "base-domains"
-  "qcheck-core" {>= "0.20"}
+  "qcheck-core" {>= "0.23"}
   "qcheck-lin" {= version}
   "qcheck-stm" {= version}
   "odoc" {with-doc}

--- a/qcheck-lin.opam
+++ b/qcheck-lin.opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.12"}
-  "qcheck-core" {>= "0.20"}
+  "qcheck-core" {>= "0.23"}
   "qcheck-multicoretests-util" {= version}
   "odoc" {with-doc}
 ]

--- a/qcheck-multicoretests-util.opam
+++ b/qcheck-multicoretests-util.opam
@@ -15,7 +15,7 @@ bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.12"}
-  "qcheck-core" {>= "0.20"}
+  "qcheck-core" {>= "0.23"}
   "odoc" {with-doc}
 ]
 build: [

--- a/qcheck-stm.opam
+++ b/qcheck-stm.opam
@@ -23,7 +23,7 @@ bug-reports: "https://github.com/ocaml-multicore/multicoretests/issues"
 depends: [
   "dune" {>= "3.0"}
   "ocaml" {>= "4.12"}
-  "qcheck-core" {>= "0.20"}
+  "qcheck-core" {>= "0.23"}
   "qcheck-multicoretests-util" {= version}
   "odoc" {with-doc}
 ]

--- a/test/util_pp.expected
+++ b/test/util_pp.expected
@@ -74,5 +74,5 @@ Test of pp_record:
 { key = 123; value = "content" }
 
 Test of pp_fun_:
-{(Some (-123456), a, xyz) -> true; (None, b, ) -> true; _ -> true}
+{(Some (-123456), 'a', "xyz") -> true; (None, 'b', "") -> true; _ -> true}
 

--- a/test/util_pp_trunc150.expected
+++ b/test/util_pp_trunc150.expected
@@ -74,5 +74,5 @@ Test of pp_record:
 { key = 123; value = "content" }
 
 Test of pp_fun_:
-{(Some (-123456), a, xyz) -> true; (None, b, ) -> true; _ -> true}
+{(Some (-123456), 'a', "xyz") -> true; (None, 'b', "") -> true; _ -> true}
 

--- a/test/util_pp_trunc79.expected
+++ b/test/util_pp_trunc79.expected
@@ -74,5 +74,5 @@ Test of pp_record:
 { key = 123; value = "content" }
 
 Test of pp_fun_:
-{(Some (-123456), a, xyz) -> true; (None, b, ) -> true; _ -> true}
+{(Some (-123456), 'a', "xyz") -> true; (None, 'b', "") -> true; _ -> true}
 


### PR DESCRIPTION
This PR bumps the qcheck-core lower bound to 0.23.

This freshly-released version means the `Util.Pp.pp_fun_` output will contain properly escaped and quoted chars and strings, and thus more comprehensible - see, e.g., the expect test diff in ef6c0067.

As an added benefit, the new lower-bound means the Lin and STM show functions can be simplified,
as they no longer need to work around QCheck.Print's lack of quoting and escaping.