### PR TITLE
Use exponential

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next release
 
+- #492: Also use the new, upstreamed `Gen.exponential` combinator in STM
 - #491: Require `qcheck.0.23`, simplify show functions by utilizing it, and update
   expect outputs accordingly
 - #486: Add `Util.Pp.pp_fun_` printer for generated `QCheck.fun_` functions

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -159,13 +159,9 @@ struct
 
     let gen_cmds_size gen s size_gen = Gen.sized_size size_gen (gen_cmds gen s)
 
-    let exp_dist_gen mean =
-      let unit_gen = Gen.float_bound_inclusive 1.0 in
-      Gen.map (fun p -> -. mean *. (log p)) unit_gen
-
     let cmd_list_size_dist mean =
       let skew = 0.75 in (* to avoid too many empty cmd lists *)
-      Gen.map (fun p -> int_of_float (p +. skew)) (exp_dist_gen mean)
+      Gen.map (fun p -> int_of_float (p +. skew)) (Gen.exponential mean)
 
     let arb_cmds s =
       let mean = 10. in (* generate on average ~10 cmds, ignoring skew *)


### PR DESCRIPTION
This is an oversight forgotten in #491: 
`qcheck-core.0.23` includes an upstreamed `Gen.exponential` combinator (from STM even) - so we should then use it.