### PR TITLE
Set MSVC timeout to 240m like the other bytecode workflows

### DIFF
--- a/.github/workflows/msvc-530-trunk-bytecode.yml
+++ b/.github/workflows/msvc-530-trunk-bytecode.yml
@@ -18,3 +18,4 @@ jobs:
       platform: msvc
       compiler_ref: refs/heads/5.3
       options: bytecode-only
+      timeout: 240

--- a/.github/workflows/msvc-540-trunk-bytecode.yml
+++ b/.github/workflows/msvc-540-trunk-bytecode.yml
@@ -18,3 +18,4 @@ jobs:
       platform: msvc
       compiler_ref: refs/heads/trunk
       options: bytecode-only
+      timeout: 240


### PR DESCRIPTION
Fixes #495