### PR TITLE
Opam-free version check in Dynarray test

### DIFF
--- a/src/dynarray/dune
+++ b/src/dynarray/dune
@@ -1,12 +1,19 @@
-;; Tests of the Dynarray library - added in 5.2
+(* -*- tuareg -*- *)
 
+(* We generate an appropriate dune stanza to avoid Dynarray tests build failures
+   on 5.0 and 5.1 with the opam-less CI GitHub action setup *)
+
+let at_least_52 = Sys.(ocaml_release.major,ocaml_release.minor) >= (5,2)
+
+let dune =
+  if at_least_52
+  then Printf.sprintf {|
 (test
  (name lin_tests)
  (modules lin_tests)
  (package multicoretests)
  (libraries qcheck-lin.domain)
- (action (run %{test} --verbose))
- (enabled_if (>= %{ocaml_version} 5.2))
+ (action (run %%{test} --verbose))
 )
 
 (test
@@ -14,6 +21,15 @@
  (modules stm_tests)
  (package multicoretests)
  (libraries qcheck-stm.sequential qcheck-stm.domain)
- (action (run %{test} --verbose))
- (enabled_if (>= %{ocaml_version} 5.2))
+ (action (run %%{test} --verbose))
 )
+|}
+  else
+    Printf.sprintf {|
+(rule
+ (alias runtest)
+ (package multicoretests)
+ (action (echo "Dynarray tests disabled as Dynarray is not available\n")))
+|}
+
+let () = Jbuild_plugin.V1.send dune

--- a/src/dynarray/dune
+++ b/src/dynarray/dune
@@ -3,10 +3,16 @@
 (* We generate an appropriate dune stanza to avoid Dynarray tests build failures
    on 5.0 and 5.1 with the opam-less CI GitHub action setup *)
 
-let at_least_52 = Sys.(ocaml_release.major,ocaml_release.minor) >= (5,2)
+(* Use ocaml_version instead of ocaml_release (from 4.14) to support 4.12 opam install *)
+let ocaml_version_pair =
+  let (major,minor) = match String.split_on_char '.' Sys.ocaml_version with
+    | major::minor::_ -> (major,minor)
+    | _ -> failwith "Unable to extract OCaml version" in
+  try (int_of_string major, int_of_string minor)
+  with Failure _ -> failwith "Failed to parse OCaml version"
 
 let dune =
-  if at_least_52
+  if ocaml_version_pair >= (5,2)
   then Printf.sprintf {|
 (test
  (name lin_tests)


### PR DESCRIPTION
Fixes #503 

By using `ocaml-config:version` from `ocamlc -config` instead of `ocaml_version` we should be able to get around having to generate a dune stanza... :crossed_fingers: 

(Note: only the first commit should be merged)