### PR TITLE
Two README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ or a particular branch of a particular fork:
       COMPILER_REF:             'refs/heads/test-me'
 ```
 
+Since [ocaml/ocaml#13458](https://github.com/ocaml/ocaml/pull/13458)
+the test suite can be triggered on an ocaml/ocaml PR (or on a fork of it)
+by adding the `run-multicoretests` label.
+
 
 A Linearization Tester
 ======================

--- a/src/README.md
+++ b/src/README.md
@@ -30,6 +30,16 @@ Tests utilizing the parallel STM.ml capability:
  - [floatarray/stm_tests.ml](floatarray/stm_tests.ml) contains sequential and
    parallel tests of the `Float.Array` module
 
+ - [gc](gc) contains sequential and parallel tests of the `Gc` module
+   - [gc/stm_tests_seq.ml](gc/stm_tests_seq.ml),
+     [gc/stm_tests_seq_child.ml](gc/stm_tests_seq_child.ml), and
+     [gc/stm_tests_par.ml](gc/stm_tests_par.ml) contains a version
+     with explicit calls to `Gc` functions, and
+   - [gc/stm_tests_impl_seq.ml](gc/stm_tests_impl_seq.ml),
+     [gc/stm_tests_impl_seq_child.ml](gc/stm_tests_impl_seq_child.ml), and
+     [gc/stm_tests_impl_par.ml](gc/stm_tests_impl_par.ml) contains a version
+     with implicit calls to the `Gc`
+
  - [hashtbl/stm_tests.ml](hashtbl/stm_tests.ml) contains sequential and
    parallel tests of the `Hashtbl` module
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,5 +1,5 @@
-Current (experimental) PBTs of multicore
-========================================
+Current PBTs of OCaml 5
+=======================
 
 Tests utilizing the parallel STM.ml capability:
 


### PR DESCRIPTION
This PR
- adds a mention of the `run-multicoretests` label to the front page `README` and
- adds a description of the new `Gc` test to `src/README` - which was forgotten in #469 

(I am also using this as an excuse to exercise the test suite with the Gc test merged to ensure the outcome is stable)