### PR TITLE
Reenable Gc.compact in Gc tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,14 @@ property can be done in two different ways:
 Issues
 ======
 
+Race condition in major heap pool orphaning during `Gc.compact` (new, fixed, runtime)
+-------------------------------------------------------------------------------------
+
+A `Gc` stress test including `Gc.compact` could trigger hangs and segfaults,
+[due to a race condition on orphaned major heap pools, which could leave
+dangling heap pointers](https://github.com/ocaml/ocaml/issues/13739).
+
+
 Tearing in `Array.sub` and `Array.copy` (new, fixed, runtime)
 -------------------------------------------------------------
 

--- a/src/gc/stm_tests_spec.ml
+++ b/src/gc/stm_tests_spec.ml
@@ -218,8 +218,11 @@ let alloc_cmds, gc_cmds =
           1, return (Major_slice 0); (* cornercase: "If n = 0, the GC will try to do enough work to ensure that the next automatic slice has no work to do" *)
           1, return Major;
           1, return Full_major;
-          1, return Compact;
-        ]) @ alloc_cmds in
+        ] @
+          (if Sys.(ocaml_release.major,ocaml_release.minor) < (5,4)
+           then [] (* known problem with Compact on <= 5.3: https://github.com/ocaml/ocaml/issues/13739 *)
+           else [1, return Compact])
+          @ alloc_cmds) in
     if Sys.(ocaml_release.major,ocaml_release.minor) > (5,3)
     then (1, Gen.return Counters)::gc_cmds  (* known problem with Counters on <= 5.2: https://github.com/ocaml/ocaml/pull/13370 *)
     else gc_cmds in

--- a/src/gc/stm_tests_spec.ml
+++ b/src/gc/stm_tests_spec.ml
@@ -218,7 +218,7 @@ let alloc_cmds, gc_cmds =
           1, return (Major_slice 0); (* cornercase: "If n = 0, the GC will try to do enough work to ensure that the next automatic slice has no work to do" *)
           1, return Major;
           1, return Full_major;
-          (* 1, return Compact; *) (* Temporarily omit Gc.compact to silence the remaining issues: #470 and #480 *)
+          1, return Compact;
         ]) @ alloc_cmds in
     if Sys.(ocaml_release.major,ocaml_release.minor) > (5,3)
     then (1, Gen.return Counters)::gc_cmds  (* known problem with Counters on <= 5.2: https://github.com/ocaml/ocaml/pull/13370 *)


### PR DESCRIPTION
This one-line PR is a left-over from #469. It was omitted from that one to move forward with the Gc tests.

I expect the PR to trigger the two outstanding Gc issues:
- #470 
- #480 

To avoid introducing noise in CI runs, it should be merged once these two have been resolved.