### PR TITLE
Change/Fix to use a symmetric barrier to synchronize domains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## NEXT RELEASE
 
-- ...
+- #509: Change/Fix to use a symmetric barrier to synchronize domains
 
 ## 0.6
 


### PR DESCRIPTION
Unless I've misunderstood something, the idea is to synchronize the two domains before the two sequences of operations are run in parallel.  The previous implementation used an asymmetric approach where one domain only spins on a flag and the other only sets the flag.  That is not really guaranteed to synchronize the domains &mdash; the domain setting the flag might start running the operations before the domain spinning on the flag gets a chance to run.  This PR changes the code to use a symmetric barrier: a counter is initialized with 2, both domains decrement the counter, and then spin until the counter becomes zero.  This should improve the synchronization between the two domains.