### PR TITLE
Introduce extended specs to allow wrapping command sequences

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 - #509: Change/Fix to use a symmetric barrier to synchronize domains
+- #511: Introduce extended specs to allow wrapping command sequences
 
 ## 0.6
 

--- a/lib/STM.ml
+++ b/lib/STM.ml
@@ -108,6 +108,19 @@ sig
       Note: [s] is in this case the model's state prior to command execution. *)
 end
 
+module type SpecExt =
+sig
+  include Spec
+
+  val wrap_cmd_seq : (unit -> 'a) -> 'a
+end
+
+module SpecDefaults =
+struct
+  let cleanup = ignore
+  let precond _ _ = true
+  let wrap_cmd_seq th = th ()
+end
 
 module Internal =
 struct

--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -164,7 +164,7 @@ sig
       {!SpecDefaults}. *)
 
   val cleanup : 'sut -> unit
-  (** [cleanup sut] just return [()]. *)
+  (** [cleanup sut] just returns [()]. *)
 
   val precond : 'cmd -> 'state -> bool
   (** [precond cmd state] just returns [true]. *)

--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -75,7 +75,9 @@ type res =
 val show_res : res -> string
 
 
-(** The specification of a state machine. *)
+(** The specification of a state machine.
+
+    See also {!SpecExt} and {!SpecDefaults}. *)
 module type Spec =
 sig
   type cmd
@@ -126,6 +128,50 @@ sig
       This is helpful to model, e.g., a [remove] [cmd] that returns the removed element. *)
 end
 
+module type SpecExt =
+sig
+  (** Extended specification of a state machine.
+
+      This signature may be extended in the future with new specifications that
+      can be given defaults via {!SpecDefaults}. *)
+
+  include Spec
+
+  val wrap_cmd_seq : (unit -> 'a) -> 'a
+  (** [wrap_cmd_seq thunk] must call [thunk ()] and return or raise whatever
+      [thunk ()] returned or raised.  [wrap_cmd_seq] is used to wrap the
+      execution of the generated command sequences.  [wrap_cmd_seq] is useful,
+      e.g., to handle effects performed by blocking primitives. *)
+end
+
+module SpecDefaults :
+sig
+  (** Default implementations for state machine specifications that can be given
+      useful defaults.
+
+      The intention is that extended spec modules would [include] the defaults:
+
+      {[
+        module MySpec = struct
+          include SpecDefaults
+
+          (* ... *)
+        end
+      ]}
+
+      This way the spec module can usually just continue working after new
+      specifications have been added to {!SpecExt} with defaults in
+      {!SpecDefaults}. *)
+
+  val cleanup : 'sut -> unit
+  (** [cleanup sut] just return [()]. *)
+
+  val precond : 'cmd -> 'state -> bool
+  (** [precond cmd state] just returns [true]. *)
+
+  val wrap_cmd_seq : (unit -> 'a) -> 'a
+  (** [wrap_cmd_seq thunk] is equivalent to [thunk ()]. *)
+end
 
 module Internal : sig
 open QCheck

--- a/lib/STM.mli
+++ b/lib/STM.mli
@@ -138,10 +138,10 @@ sig
   include Spec
 
   val wrap_cmd_seq : (unit -> 'a) -> 'a
-  (** [wrap_cmd_seq thunk] must call [thunk ()] and return or raise whatever
-      [thunk ()] returned or raised.  [wrap_cmd_seq] is used to wrap the
-      execution of the generated command sequences.  [wrap_cmd_seq] is useful,
-      e.g., to handle effects performed by blocking primitives. *)
+  (** [wrap_cmd_seq] is used to wrap the execution of the generated command
+      sequences. [wrap_cmd_seq] is useful, e.g., to handle effects performed by
+      blocking primitives. [wrap_cmd_seq thunk] must call [thunk ()] and return
+      or raise whatever [thunk ()] returned or raised. *)
 end
 
 module SpecDefaults :

--- a/lib/STM_domain.mli
+++ b/lib/STM_domain.mli
@@ -96,3 +96,6 @@ module Make : functor (Spec : STM.Spec) ->
         interleaving search like {!agree_test_par} and {!neg_agree_test_par}. *)
 
  end
+
+module MakeExt : functor (Spec : STM.SpecExt) ->
+  module type of Make (Spec)

--- a/lib/STM_sequential.mli
+++ b/lib/STM_sequential.mli
@@ -25,3 +25,6 @@ module Make : functor (Spec : STM.Spec) ->
     (** A negative agreement test (for convenience). Accepts two labeled parameters:
         [count] is the test count and [name] is the printed test name. *)
   end
+
+module MakeExt : functor (Spec : STM.SpecExt) ->
+  module type of Make (Spec)

--- a/lib/STM_thread.mli
+++ b/lib/STM_thread.mli
@@ -27,3 +27,7 @@ module Make : functor (Spec : STM.Spec) ->
 
   end
   [@@alert experimental "This module is experimental: It may fail to trigger concurrency issues that are present."]
+
+module MakeExt : functor (Spec : STM.SpecExt) ->
+  module type of Make (Spec) [@@alert "-experimental"]
+  [@@alert experimental "This module is experimental: It may fail to trigger concurrency issues that are present."]


### PR DESCRIPTION
See #510.

Contrary to what #510 concluded with, I decided to introduce
- an extended `Spec` signature, `SpecExt`,
- a module of default specs, `SpecDefaults`,
- and extended functors, `STM_sequential.MakeExt`, `STM_domain.MakeExt`, and `STM_thread.MakeExt`.

The reason for this is that introducing `wrapped` variants of the various functions produced by the functors would have roughly meant duplicating all of the functions.  This approach is much more incremental and also potentially allows the `Spec` interface to the extended in the future.

The idea is that one always uses the `SpecDefaults`:

```ocaml
module MySpec = struct
  include SpecDefaults
  ...
end
```

This way new optional specs can be added as long as `SpecDetaults` can provide default implementations of such additions.

There is [a PR to Picos that uses this PR](https://github.com/ocaml-multicore/picos/pull/341).

TODO:
- [x] Agree this is the way to go
- [x] Document the API additions
- [x] Finish the implementation, including creating `STM_thread.MakeExt`, and making sure operations are wrapped in all cases
- [x] Update changelog 