### PR TITLE
Use setup-ocaml 3 for opam workflow

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install OCaml compiler
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
           opam-depext: false

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -37,7 +37,6 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          opam-depext: false
 
       - name: Test installation of the OPAM packages
         run: |

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -25,7 +25,8 @@ jobs:
           - 5.0.0
           - 5.1.0
           - 5.2.0
-          - ocaml-variants.5.3.0+trunk
+          - 5.3.0
+          - ocaml-variants.5.4.0+trunk
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
We started observing opam workflow failures, e.g., on #509, due to `ubuntu-latest` switching to Ubuntu 24.04.
Switching to setup-ocaml@v3 fixes this. See https://github.com/ocaml/setup-ocaml/issues/872