### PR TITLE
Lin bytes adjustments

### DIFF
--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -7,7 +7,7 @@ module BConf = struct
   let cleanup _ = ()
 
   open Lin
-
+  let int,string = nat_small, string_small_printable
   let api = [
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
@@ -21,6 +21,6 @@ module BT_domain = Lin_domain.Make(BConf)
 module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
 ;;
 QCheck_base_runner.run_tests_main [
-  BT_domain.lin_test ~count:1000 ~name:"Lin Bytes test with Domain";
+  BT_domain.neg_lin_test ~count:1000 ~name:"Lin Bytes test with Domain";
   BT_thread.lin_test ~count:1000 ~name:"Lin Bytes test with Thread";
 ]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -22,5 +22,5 @@ module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
 ;;
 QCheck_base_runner.run_tests_main [
   BT_domain.neg_lin_test ~count:1000 ~name:"Lin Bytes test with Domain";
-  BT_thread.lin_test ~count:1000 ~name:"Lin Bytes test with Thread";
+  BT_thread.lin_test     ~count:250  ~name:"Lin Bytes test with Thread";
 ]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -10,6 +10,7 @@ module BConf = struct
   let int,string = nat_small, string_small_printable
   let api = [
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
+    val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
     val_ "Bytes.length"      Bytes.length      (t @-> returning int);
     val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);


### PR DESCRIPTION
Looking at the `Lin Bytes` test I noticed an embarrasing oversight: it was using the uniform `int` generators.
- The first commit thus adjusts them to use small ones - meaning we start triggering counterexamples - and thus turning the test into a negative one. Bytes is unsafe to use in parallel after all :shrug: 
- The second commit reduces the `Thread` count to 250, like, e.g., the similar `Stack Thread` test
- The third commit adds `Bytes.set` - another unexpected oversight :grimacing: 

(In fairness the STM Bytes tests are free from both of the above oversights)

Fixes #515