### PR TITLE
Expand on Lin Bytes test and add stress test

### DIFF
--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -45,7 +45,7 @@ module BT_domain = Lin_domain.Make(BConf)
 module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
 ;;
 QCheck_base_runner.run_tests_main [
-  BT_domain.neg_lin_test ~count:2500 ~name:"Lin Bytes test with Domain";
+  BT_domain.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Domain";
   BT_thread.lin_test     ~count:250  ~name:"Lin Bytes test with Thread";
   BT_domain.stress_test  ~count:1000 ~name:"Lin Bytes stress test with Domain";
 ]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -29,9 +29,15 @@ module BConf = struct
     val_ "Bytes.contains"          Bytes.contains          (t @-> char @-> returning_or_exc bool);
     val_ "Bytes.contains_from"     Bytes.contains_from     (t @-> int @-> char @-> returning_or_exc bool);
     val_ "Bytes.rcontains_from"    Bytes.rcontains_from    (t @-> int @-> char @-> returning_or_exc bool);
+    (* UTF codecs and validations *)
     val_ "Bytes.is_valid_utf_8"    Bytes.is_valid_utf_8    (t @-> returning bool);
     val_ "Bytes.is_valid_utf_16be" Bytes.is_valid_utf_16be (t @-> returning bool);
     val_ "Bytes.is_valid_utf_16le" Bytes.is_valid_utf_16le (t @-> returning bool);
+    (* Binary encoding/decoding of integers *)
+    val_ "Bytes.get_uint8"         Bytes.get_uint8         (t @-> int @-> returning_or_exc int);
+    val_ "Bytes.get_int8"          Bytes.get_int8          (t @-> int @-> returning_or_exc int);
+    val_ "Bytes.set_uint8"         Bytes.set_uint8         (t @-> int @-> int @-> returning_or_exc unit);
+    val_ "Bytes.set_int8"          Bytes.set_int8          (t @-> int @-> int @-> returning_or_exc unit);
   ]
 end
 

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -26,6 +26,9 @@ module BConf = struct
     val_ "Bytes.index_from_opt"  Bytes.index_from_opt  (t @-> int @-> char @-> returning_or_exc (option int));
     val_ "Bytes.rindex_from"     Bytes.rindex_from     (t @-> int @-> char @-> returning_or_exc int);
     val_ "Bytes.rindex_from_opt" Bytes.rindex_from_opt (t @-> int @-> char @-> returning_or_exc (option int));
+    val_ "Bytes.contains"        Bytes.contains        (t @-> char @-> returning_or_exc bool);
+    val_ "Bytes.contains_from"   Bytes.contains_from   (t @-> int @-> char @-> returning_or_exc bool);
+    val_ "Bytes.rcontains_from"  Bytes.rcontains_from  (t @-> int @-> char @-> returning_or_exc bool);
   ]
 end
 

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -13,6 +13,7 @@ module BConf = struct
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
     val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.to_string"   Bytes.to_string   (t @-> returning string);
+    val_ "Bytes.sub"         Bytes.sub         (t @-> int @-> int @-> returning_or_exc bytes);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
     val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -9,26 +9,29 @@ module BConf = struct
   open Lin
   let int,string = nat_small, string_small_printable
   let api = [
-    val_ "Bytes.length"          Bytes.length          (t @-> returning int);
-    val_ "Bytes.get"             Bytes.get             (t @-> int @-> returning_or_exc char);
-    val_ "Bytes.set"             Bytes.set             (t @-> int @-> char @-> returning_or_exc unit);
-    val_ "Bytes.copy"            Bytes.copy            (t @-> returning bytes);
-    val_ "Bytes.to_string"       Bytes.to_string       (t @-> returning string);
-    val_ "Bytes.sub"             Bytes.sub             (t @-> int @-> int @-> returning_or_exc bytes);
-    val_ "Bytes.sub_string"      Bytes.sub_string      (t @-> int @-> int @-> returning_or_exc string);
-    val_ "Bytes.fill"            Bytes.fill            (t @-> int @-> int @-> char @-> returning_or_exc unit);
-    val_ "Bytes.blit_string"     Bytes.blit_string     (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
-    val_ "Bytes.index"           Bytes.index           (t @-> char @-> returning_or_exc int);
-    val_ "Bytes.index_opt"       Bytes.index_opt       (t @-> char @-> returning (option int));
-    val_ "Bytes.rindex"          Bytes.rindex          (t @-> char @-> returning_or_exc int);
-    val_ "Bytes.rindex_opt"      Bytes.rindex_opt      (t @-> char @-> returning (option int));
-    val_ "Bytes.index_from"      Bytes.index_from      (t @-> int @-> char @-> returning_or_exc int);
-    val_ "Bytes.index_from_opt"  Bytes.index_from_opt  (t @-> int @-> char @-> returning_or_exc (option int));
-    val_ "Bytes.rindex_from"     Bytes.rindex_from     (t @-> int @-> char @-> returning_or_exc int);
-    val_ "Bytes.rindex_from_opt" Bytes.rindex_from_opt (t @-> int @-> char @-> returning_or_exc (option int));
-    val_ "Bytes.contains"        Bytes.contains        (t @-> char @-> returning_or_exc bool);
-    val_ "Bytes.contains_from"   Bytes.contains_from   (t @-> int @-> char @-> returning_or_exc bool);
-    val_ "Bytes.rcontains_from"  Bytes.rcontains_from  (t @-> int @-> char @-> returning_or_exc bool);
+    val_ "Bytes.length"            Bytes.length            (t @-> returning int);
+    val_ "Bytes.get"               Bytes.get               (t @-> int @-> returning_or_exc char);
+    val_ "Bytes.set"               Bytes.set               (t @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.copy"              Bytes.copy              (t @-> returning bytes);
+    val_ "Bytes.to_string"         Bytes.to_string         (t @-> returning string);
+    val_ "Bytes.sub"               Bytes.sub               (t @-> int @-> int @-> returning_or_exc bytes);
+    val_ "Bytes.sub_string"        Bytes.sub_string        (t @-> int @-> int @-> returning_or_exc string);
+    val_ "Bytes.fill"              Bytes.fill              (t @-> int @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.blit_string"       Bytes.blit_string       (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
+    val_ "Bytes.index"             Bytes.index             (t @-> char @-> returning_or_exc int);
+    val_ "Bytes.index_opt"         Bytes.index_opt         (t @-> char @-> returning (option int));
+    val_ "Bytes.rindex"            Bytes.rindex            (t @-> char @-> returning_or_exc int);
+    val_ "Bytes.rindex_opt"        Bytes.rindex_opt        (t @-> char @-> returning (option int));
+    val_ "Bytes.index_from"        Bytes.index_from        (t @-> int @-> char @-> returning_or_exc int);
+    val_ "Bytes.index_from_opt"    Bytes.index_from_opt    (t @-> int @-> char @-> returning_or_exc (option int));
+    val_ "Bytes.rindex_from"       Bytes.rindex_from       (t @-> int @-> char @-> returning_or_exc int);
+    val_ "Bytes.rindex_from_opt"   Bytes.rindex_from_opt   (t @-> int @-> char @-> returning_or_exc (option int));
+    val_ "Bytes.contains"          Bytes.contains          (t @-> char @-> returning_or_exc bool);
+    val_ "Bytes.contains_from"     Bytes.contains_from     (t @-> int @-> char @-> returning_or_exc bool);
+    val_ "Bytes.rcontains_from"    Bytes.rcontains_from    (t @-> int @-> char @-> returning_or_exc bool);
+    val_ "Bytes.is_valid_utf_8"    Bytes.is_valid_utf_8    (t @-> returning bool);
+    val_ "Bytes.is_valid_utf_16be" Bytes.is_valid_utf_16be (t @-> returning bool);
+    val_ "Bytes.is_valid_utf_16le" Bytes.is_valid_utf_16le (t @-> returning bool);
   ]
 end
 

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -9,16 +9,24 @@ module BConf = struct
   open Lin
   let int,string = nat_small, string_small_printable
   let api = [
-    val_ "Bytes.length"      Bytes.length      (t @-> returning int);
-    val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
-    val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
-    val_ "Bytes.copy"        Bytes.copy        (t @-> returning bytes);
-    val_ "Bytes.to_string"   Bytes.to_string   (t @-> returning string);
-    val_ "Bytes.sub"         Bytes.sub         (t @-> int @-> int @-> returning_or_exc bytes);
-    val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
-    val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
-    val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
-    val_ "Bytes.index_from"  Bytes.index_from  (t @-> int @-> char @-> returning_or_exc int)]
+    val_ "Bytes.length"          Bytes.length          (t @-> returning int);
+    val_ "Bytes.get"             Bytes.get             (t @-> int @-> returning_or_exc char);
+    val_ "Bytes.set"             Bytes.set             (t @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.copy"            Bytes.copy            (t @-> returning bytes);
+    val_ "Bytes.to_string"       Bytes.to_string       (t @-> returning string);
+    val_ "Bytes.sub"             Bytes.sub             (t @-> int @-> int @-> returning_or_exc bytes);
+    val_ "Bytes.sub_string"      Bytes.sub_string      (t @-> int @-> int @-> returning_or_exc string);
+    val_ "Bytes.fill"            Bytes.fill            (t @-> int @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.blit_string"     Bytes.blit_string     (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
+    val_ "Bytes.index"           Bytes.index           (t @-> char @-> returning_or_exc int);
+    val_ "Bytes.index_opt"       Bytes.index_opt       (t @-> char @-> returning (option int));
+    val_ "Bytes.rindex"          Bytes.rindex          (t @-> char @-> returning_or_exc int);
+    val_ "Bytes.rindex_opt"      Bytes.rindex_opt      (t @-> char @-> returning (option int));
+    val_ "Bytes.index_from"      Bytes.index_from      (t @-> int @-> char @-> returning_or_exc int);
+    val_ "Bytes.index_from_opt"  Bytes.index_from_opt  (t @-> int @-> char @-> returning_or_exc (option int));
+    val_ "Bytes.rindex_from"     Bytes.rindex_from     (t @-> int @-> char @-> returning_or_exc int);
+    val_ "Bytes.rindex_from_opt" Bytes.rindex_from_opt (t @-> int @-> char @-> returning_or_exc (option int));
+  ]
 end
 
 module BT_domain = Lin_domain.Make(BConf)

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -47,4 +47,5 @@ module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
 QCheck_base_runner.run_tests_main [
   BT_domain.neg_lin_test ~count:2500 ~name:"Lin Bytes test with Domain";
   BT_thread.lin_test     ~count:250  ~name:"Lin Bytes test with Thread";
+  BT_domain.stress_test  ~count:1000 ~name:"Lin Bytes stress test with Domain";
 ]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -12,6 +12,7 @@ module BConf = struct
     val_ "Bytes.length"      Bytes.length      (t @-> returning int);
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
     val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.copy"        Bytes.copy        (t @-> returning bytes);
     val_ "Bytes.to_string"   Bytes.to_string   (t @-> returning string);
     val_ "Bytes.sub"         Bytes.sub         (t @-> int @-> int @-> returning_or_exc bytes);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -9,10 +9,10 @@ module BConf = struct
   open Lin
   let int,string = nat_small, string_small_printable
   let api = [
+    val_ "Bytes.length"      Bytes.length      (t @-> returning int);
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
     val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
-    val_ "Bytes.length"      Bytes.length      (t @-> returning int);
     val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);
     val_ "Bytes.index_from"  Bytes.index_from  (t @-> int @-> char @-> returning_or_exc int)]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -12,6 +12,7 @@ module BConf = struct
     val_ "Bytes.length"      Bytes.length      (t @-> returning int);
     val_ "Bytes.get"         Bytes.get         (t @-> int @-> returning_or_exc char);
     val_ "Bytes.set"         Bytes.set         (t @-> int @-> char @-> returning_or_exc unit);
+    val_ "Bytes.to_string"   Bytes.to_string   (t @-> returning string);
     val_ "Bytes.sub_string"  Bytes.sub_string  (t @-> int @-> int @-> returning_or_exc string);
     val_ "Bytes.fill"        Bytes.fill        (t @-> int @-> int @-> char @-> returning_or_exc unit);
     val_ "Bytes.blit_string" Bytes.blit_string (string @-> int @-> t @-> int @-> int @-> returning_or_exc unit);


### PR DESCRIPTION
While looking at #520 I noticed the long-running Lin Bytes test contains only few of the `Bytes` module binding.
This PR adds a bunch more. 

Adding these seem to have a positive effect on quickly reducing a counterexample, when I run this locally.
As such, it may help resolve #520.

While at it, the PR also adds a `Lin` `stress_test` of these many bindings (now well beyond what `src/bytes/stm_tests.ml` covers).