### PR TITLE
CI: Update `dune` to support `trunk`

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: 3.16.0
+          ref: 2de53980efa731eacf5475139d9a5a218f9752a0
           path: dune
         if: steps.cache.outputs.cache-hit != 'true'
 


### PR DESCRIPTION
Unfortunately, this is not part of a released version yet.