### PR TITLE
CI: Pin dune in opam workflows too

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Test installation of the OPAM packages
         run: |
+          opam pin -n add https://github.com/ocaml/dune.git\#2de53980efa731eacf5475139d9a5a218f9752a0
           opam install --with-test ./qcheck-multicoretests-util.opam ./qcheck-lin.opam ./qcheck-stm.opam
 
       - name: Show configuration

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -17,6 +17,7 @@ jobs:
       QCHECK_MSG_INTERVAL:      '60'
 
     strategy:
+      fail-fast: false
       matrix:
         ocaml-compiler:
           - 4.12.x


### PR DESCRIPTION
It has been ~3 weeks since #531, there hasn't been a dune release restoring `trunk` support yet, and I am now getting sufficiently annoyed having to repeatedly argue in CI failure runs.

This PR therefore pins dune to a trunk compatible version in the opam install workflows, akin to #531.

In the second commit I've also removed the "fail fast" mode, as in cases such as this, it is actually helpful to run all workflows to assess how many versions are affected as part of understanding the reason for a failure. I'd therefore hope to keep that commit, once we get a new `dune` release and remove #531 and 9d3625b526a9718558ba076fe4d51edb476028ac again.