### PR TITLE
Improve context switching chance in `Lin_thread` and `STM_thread` modes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## NEXT RELEASE
 
-- ...
+- #540: Significantly increase the probability of context switching in `Lin_thread`
+        and `STM_thread` by utilizing `Gc.Memprof` callbacks. Avoid on 5.0-5.2
+        without `Gc.Memprof` support.
 
 ## 0.7
 

--- a/lib/STM_thread.mli
+++ b/lib/STM_thread.mli
@@ -1,4 +1,21 @@
-(** Module for building concurrent STM tests over {!Thread}s *)
+(** Module for building concurrent [STM] tests over {!Thread}s
+
+    Context switches in {!Thread}s may happen
+    - at allocations and
+    - at safepoints {:https://github.com/ocaml/ocaml/pull/10039}.
+
+    This module relies on [Gc.Memprof] support to trigger more frequent context
+    switching between threads at allocation sites. This works well in OCaml
+    4.11.0-4.14.x and 5.3.0 onwards where [Gc.Memprof] is available.
+
+    In OCaml 5.0-5.2 without [Gc.Memprof] support the context switching at
+    allocation sites will be inferior. As a consequence the module may fail to
+    trigger concurrency issues.
+
+    Context switches at safepoints will trigger much less frequently. This
+    means the module may fail to trigger concurrency issues in connection with
+    these. Consider yourself warned.
+*)
 
 module Make : functor (Spec : STM.Spec) ->
   sig

--- a/lib/STM_thread.mli
+++ b/lib/STM_thread.mli
@@ -26,8 +26,6 @@ module Make : functor (Spec : STM.Spec) ->
         [count] is the test count and [name] is the printed test name. *)
 
   end
-  [@@alert experimental "This module is experimental: It may fail to trigger concurrency issues that are present."]
 
 module MakeExt : functor (Spec : STM.SpecExt) ->
-  module type of Make (Spec) [@@alert "-experimental"]
-  [@@alert experimental "This module is experimental: It may fail to trigger concurrency issues that are present."]
+  module type of Make (Spec)

--- a/lib/lin_domain.mli
+++ b/lib/lin_domain.mli
@@ -1,6 +1,6 @@
 open Lin
 
-(** functor to build an internal module representing parallel tests *)
+(** Functor to build an internal module representing parallel tests *)
 module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
   val lin_prop : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
@@ -11,7 +11,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
 end
   [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
-(** functor to build a module for parallel testing *)
+(** Functor to build a module for parallel testing *)
 module Make (Spec : Spec) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   (** [lin_test ~count:c ~name:n] builds a parallel test with the name [n] that

--- a/lib/lin_effect.mli
+++ b/lib/lin_effect.mli
@@ -1,6 +1,6 @@
 open Lin
 
-(** functor to build an internal module representing {!Stdlib.Effect}-based tests *)
+(** Functor to build an internal module representing {!Stdlib.Effect}-based tests *)
 module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   module EffSpec : sig
     type cmd
@@ -20,7 +20,7 @@ val yield : unit -> unit
 (** Helper function to yield control in the underlying {!Stdlib.Effect}-based scheduler
 *)
 
-(** functor to build a module for [Effect]-based testing *)
+(** Functor to build a module for [Effect]-based testing *)
 module Make (Spec : Spec) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   (** [lin_test ~count:c ~name:n] builds an {!Stdlib.Effect}-based test with the name

--- a/lib/lin_thread.ml
+++ b/lib/lin_thread.ml
@@ -30,7 +30,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
     let sut = Spec.init () in
     let obs1, obs2 = ref (Ok []), ref (Ok []) in
     (* Gc.Memprof.{start,stop} raises Failure on OCaml 5.0 and 5.1 *)
-    (try ignore (Gc.Memprof.start ~sampling_rate:1e-3 ~callstack_size:0 yield_tracker) with Failure _ -> ());
+    (try ignore (Gc.Memprof.start ~sampling_rate:1e-1 ~callstack_size:0 yield_tracker) with Failure _ -> ());
     let pref_obs = interp_plain sut seq_pref in
     let wait = ref true in
     let th1 = Thread.create (fun () -> while !wait do Thread.yield () done; obs1 := try Ok (interp_thread sut cmds1) with exn -> Error exn) () in
@@ -50,10 +50,10 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
             (pref_obs,!obs1,!obs2)
 
   let lin_test ~count ~name =
-    lin_test ~rep_count:100 ~count ~retries:5 ~name ~lin_prop:lin_prop
+    lin_test ~rep_count:3 ~count ~retries:25 ~name ~lin_prop:lin_prop
 
   let neg_lin_test ~count ~name =
-    neg_lin_test ~rep_count:100 ~count ~retries:5 ~name ~lin_prop:lin_prop
+    neg_lin_test ~rep_count:3 ~count ~retries:25 ~name ~lin_prop:lin_prop
 end
 
 module Make (Spec : Spec) = Make_internal(MakeCmd(Spec))

--- a/lib/lin_thread.ml
+++ b/lib/lin_thread.ml
@@ -4,6 +4,14 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
   module M = Internal.Make(Spec) [@alert "-internal"]
   include M
 
+  let alloc_callback _src =
+    Thread.yield ();
+    None
+
+  let yield_tracker =
+    Gc.Memprof.{ null_tracker with alloc_minor = alloc_callback;
+                                   alloc_major = alloc_callback; }
+
   (* Note: On purpose we use
      - a non-tail-recursive function and
      - an (explicit) allocation in the loop body
@@ -21,12 +29,14 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) = struct
   let lin_prop (seq_pref, cmds1, cmds2) =
     let sut = Spec.init () in
     let obs1, obs2 = ref (Ok []), ref (Ok []) in
+    let _ = Gc.Memprof.start ~sampling_rate:1e-3 ~callstack_size:0 yield_tracker in
     let pref_obs = interp_plain sut seq_pref in
     let wait = ref true in
     let th1 = Thread.create (fun () -> while !wait do Thread.yield () done; obs1 := try Ok (interp_thread sut cmds1) with exn -> Error exn) () in
     let th2 = Thread.create (fun () -> wait := false; obs2 := try Ok (interp_thread sut cmds2) with exn -> Error exn) () in
     Thread.join th1;
     Thread.join th2;
+    Gc.Memprof.stop ();
     Spec.cleanup sut;
     let obs1 = match !obs1 with Ok v -> ref v | Error exn -> raise exn in
     let obs2 = match !obs2 with Ok v -> ref v | Error exn -> raise exn in

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -1,3 +1,22 @@
+(** Module for building concurrent [Lin] tests over {!Thread}s
+
+    Context switches in {!Thread}s may happen
+    - at allocations and
+    - at safepoints {:https://github.com/ocaml/ocaml/pull/10039}.
+
+    This module relies on [Gc.Memprof] support to trigger more frequent context
+    switching between threads at allocation sites. This works well in OCaml
+    4.11.0-4.14.x and 5.3.0 onwards where [Gc.Memprof] is available.
+
+    In OCaml 5.0-5.2 without [Gc.Memprof] support the context switching at
+    allocation sites will be inferior. As a consequence the module may fail to
+    trigger concurrency issues.
+
+    Context switches at safepoints will trigger much less frequently. This
+    means the module may fail to trigger concurrency issues in connection with
+    these. Consider yourself warned.
+*)
+
 open Lin
 
 (** functor to build an internal module representing concurrent tests *)

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -19,7 +19,7 @@
 
 open Lin
 
-(** functor to build an internal module representing concurrent tests *)
+(** Functor to build an internal module representing concurrent tests *)
 module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
   val arb_cmds_triple : int -> int -> (Spec.cmd list * Spec.cmd list * Spec.cmd list) QCheck.arbitrary
   val lin_prop : (Spec.cmd list * Spec.cmd list * Spec.cmd list) -> bool
@@ -28,7 +28,7 @@ module Make_internal (Spec : Internal.CmdSpec [@alert "-internal"]) : sig
 end
   [@@alert internal "This module is exposed for internal uses only, its API may change at any time"]
 
-(** functor to build a module for concurrent testing *)
+(** Functor to build a module for concurrent testing *)
 module Make (Spec : Spec) : sig
   val lin_test : count:int -> name:string -> QCheck.Test.t
   (** [lin_test ~count:c ~name:n] builds a concurrent test with the name [n]

--- a/lib/lin_thread.mli
+++ b/lib/lin_thread.mli
@@ -25,4 +25,3 @@ module Make (Spec : Spec) : sig
       afterwards.
   *)
 end
-[@@alert experimental "This module is experimental: It may fail to trigger concurrency issues that are present."]

--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -42,7 +42,7 @@ module BConf = struct
 end
 
 module BT_domain = Lin_domain.Make(BConf)
-module BT_thread = Lin_thread.Make(BConf) [@alert "-experimental"]
+module BT_thread = Lin_thread.Make(BConf)
 ;;
 QCheck_base_runner.run_tests_main [
   BT_domain.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Domain";

--- a/src/io/lin_tests_thread.ml
+++ b/src/io/lin_tests_thread.ml
@@ -2,7 +2,7 @@
 (*                      Tests of In_channels                              *)
 (* ********************************************************************** *)
 
-module IC_thread = Lin_thread.Make(Lin_tests_spec_io.ICConf) [@@alert "-experimental"]
+module IC_thread = Lin_thread.Make(Lin_tests_spec_io.ICConf)
 
 let _ =
   QCheck_base_runner.run_tests_main [

--- a/src/neg_tests/CList.ml
+++ b/src/neg_tests/CList.ml
@@ -14,6 +14,18 @@ let rec add_node list_head n =
   else
     add_node list_head n
 
+let rec add_node_thread list_head n =
+  (* try to add a new node to head *)
+  let old_head = Atomic.get list_head in
+  if Atomic.get list_head = old_head then begin
+    (* introduce bug: as above but context switch can happen when allocating *)
+    let new_node = { value = n ; next = (Some old_head) } in
+    Atomic.set list_head new_node;
+    true
+  end
+  else
+    add_node_thread list_head n
+
 let list_init i = Atomic.make { value = i ; next = None }
 
 let member list_head n =

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -100,8 +100,7 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_tests_common qcheck-lin.thread)
- ; (action (run %{test} --verbose))
- (action (progn))
+ (action (run %{test} --verbose))
 )
 
 (test
@@ -131,7 +130,8 @@
  (package multicoretests)
  (flags (:standard -w -27))
  (libraries lin_internal_tests_common qcheck-lin.thread)
- (action (run %{test} --verbose))
+ ; (action (run %{test} --verbose))
+ (action (progn))
 )
 
 (test

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -46,10 +46,18 @@
 )
 
 (test
- (name stm_tests_conclist)
- (modules stm_tests_conclist)
+ (name stm_tests_clist_sequential)
+ (modules stm_tests_clist_spec stm_tests_clist_sequential)
  (package multicoretests)
- (libraries CList qcheck-stm.sequential qcheck-stm.domain)
+ (libraries CList qcheck-stm.sequential)
+ (action (run %{test} --verbose))
+)
+
+(test
+ (name stm_tests_clist_domain)
+ (modules stm_tests_clist_spec stm_tests_clist_domain)
+ (package multicoretests)
+ (libraries CList qcheck-stm.domain)
  (action (run %{test} --verbose))
 )
 

--- a/src/neg_tests/dune
+++ b/src/neg_tests/dune
@@ -61,6 +61,14 @@
  (action (run %{test} --verbose))
 )
 
+(test
+ (name stm_tests_clist_thread)
+ (modules stm_tests_clist_spec stm_tests_clist_thread)
+ (package multicoretests)
+ (libraries CList qcheck-stm.thread)
+ (action (run %{test} --verbose))
+)
+
 ;; Linearization tests of ref and Clist with Lin
 
 (library

--- a/src/neg_tests/lin_internal_tests_common.ml
+++ b/src/neg_tests/lin_internal_tests_common.ml
@@ -188,13 +188,20 @@ end
 (* ********************************************************************** *)
 (*                  Tests of the buggy concurrent list CList              *)
 (* ********************************************************************** *)
-module CLConf (T : sig
-                     type t
-                     val zero : t
-                     val of_int : int -> t
-                     val to_string : t -> string
-                     val shrink : t Shrink.t
-                   end) =
+module CLConf
+    (CList : sig
+       type 'a conc_list
+       val list_init : 'a -> 'a conc_list Atomic.t
+       val add_node: 'a conc_list Atomic.t -> 'a -> bool
+       val member : 'a conc_list Atomic.t -> 'a -> bool
+     end)
+    (T : sig
+       type t
+       val zero : t
+       val of_int : int -> t
+       val to_string : t -> string
+       val shrink : t Shrink.t
+     end) =
 struct
   module Lin = Lin.Internal [@alert "-internal"]
 

--- a/src/neg_tests/lin_internal_tests_domain.ml
+++ b/src/neg_tests/lin_internal_tests_domain.ml
@@ -2,8 +2,8 @@ open Lin_internal_tests_common
 
 module RT_int_domain = Lin_domain.Make_internal(RConf_int) [@alert "-internal"]
 module RT_int64_domain = Lin_domain.Make_internal(RConf_int64) [@alert "-internal"]
-module CLT_int_domain = Lin_domain.Make_internal(CLConf (Int)) [@alert "-internal"]
-module CLT_int64_domain = Lin_domain.Make_internal(CLConf (Int64)) [@alert "-internal"]
+module CLT_int_domain = Lin_domain.Make_internal(CLConf(CList)(Int)) [@alert "-internal"]
+module CLT_int64_domain = Lin_domain.Make_internal(CLConf(CList)(Int64)) [@alert "-internal"]
 
 (** This is a driver of the negative tests over the Domain module *)
 

--- a/src/neg_tests/lin_internal_tests_effect.ml
+++ b/src/neg_tests/lin_internal_tests_effect.ml
@@ -92,7 +92,7 @@ module RT_int64'_effect = Lin_effect.Make_internal(RConf_int64') [@alert "-inter
 
 module CLConf_int' =
 struct
-  include CLConf(Int)
+  include CLConf(CList)(Int)
   type res =
     | RAdd_node of (bool, exn) result
     | RMember of bool
@@ -116,12 +116,12 @@ struct
     | Add_node i -> RAdd_node (try Lin_effect.yield (); Ok (CList.add_node r i) with exn -> Error exn)
     | Member i   -> RMember (CList.member r i)
 end
-module CLT_int_effect = Lin_effect.Make_internal(CLConf (Int)) [@alert "-internal"]
+module CLT_int_effect = Lin_effect.Make_internal(CLConf(CList)(Int)) [@alert "-internal"]
 module CLT_int'_effect = Lin_effect.Make_internal(CLConf_int') [@alert "-internal"]
 
 module CLConf_int64' =
 struct
-  include CLConf(Int64)
+  include CLConf(CList)(Int64)
   type res =
     | RAdd_node of (bool, exn) result
     | RMember of bool
@@ -145,7 +145,7 @@ struct
     | Add_node i -> RAdd_node (try Lin_effect.yield (); Ok (CList.add_node r i) with exn -> Error exn)
     | Member i   -> RMember (CList.member r i)
 end
-module CLT_int64_effect = Lin_effect.Make_internal(CLConf(Int64)) [@alert "-internal"]
+module CLT_int64_effect = Lin_effect.Make_internal(CLConf(CList)(Int64)) [@alert "-internal"]
 module CLT_int64'_effect = Lin_effect.Make_internal(CLConf_int64') [@alert "-internal"]
 ;;
 QCheck_base_runner.run_tests_main

--- a/src/neg_tests/lin_internal_tests_thread_conclist.ml
+++ b/src/neg_tests/lin_internal_tests_thread_conclist.ml
@@ -1,9 +1,9 @@
 open Lin_internal_tests_common
 
 (** This is a driver of the negative CList tests over the Thread module *)
-
-module CLT_int_thread = Lin_thread.Make_internal(CLConf (Int)) [@alert "-internal"]
-module CLT_int64_thread = Lin_thread.Make_internal(CLConf (Int64)) [@alert "-internal"]
+module CList_bis = struct include CList let add_node = add_node_thread end
+module CLT_int_thread = Lin_thread.Make_internal(CLConf(CList_bis)(Int)) [@alert "-internal"]
+module CLT_int64_thread = Lin_thread.Make_internal(CLConf(CList_bis)(Int64)) [@alert "-internal"]
 
 let _ =
   if Sys.backend_type = Sys.Bytecode then
@@ -11,6 +11,6 @@ let _ =
   else
     let count = 1000 in
     QCheck_base_runner.run_tests_main [
-      CLT_int_thread.lin_test   ~count ~name:"Lin.Internal CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-      CLT_int64_thread.lin_test ~count ~name:"Lin.Internal CList int64 test with Thread" (* not triggering context switch, unfortunately *)
+      CLT_int_thread.neg_lin_test   ~count ~name:"Lin.Internal CList int test with Thread";
+      CLT_int64_thread.neg_lin_test ~count ~name:"Lin.Internal CList int64 test with Thread"
     ]

--- a/src/neg_tests/lin_tests_common.ml
+++ b/src/neg_tests/lin_tests_common.ml
@@ -56,7 +56,13 @@ module Ref_int64_spec : Spec = struct
 (**                  Tests of the buggy concurrent list CList              *)
 (** ********************************************************************** *)
 
-module CList_spec_int : Spec =
+module CList_spec_int
+    (CList : sig
+       type 'a conc_list
+       val list_init : 'a -> 'a conc_list Atomic.t
+       val add_node: 'a conc_list Atomic.t -> 'a -> bool
+       val member : 'a conc_list Atomic.t -> 'a -> bool
+     end) : Spec =
 struct
   type t = int CList.conc_list Atomic.t
   let init () = CList.list_init 0
@@ -68,7 +74,13 @@ struct
     ]
   end
 
-module CList_spec_int64 : Spec =
+module CList_spec_int64
+    (CList : sig
+       type 'a conc_list
+       val list_init : 'a -> 'a conc_list Atomic.t
+       val add_node: 'a conc_list Atomic.t -> 'a -> bool
+       val member : 'a conc_list Atomic.t -> 'a -> bool
+     end) : Spec =
 struct
   type t = int64 CList.conc_list Atomic.t
   let init () = CList.list_init Int64.zero

--- a/src/neg_tests/lin_tests_domain.ml
+++ b/src/neg_tests/lin_tests_domain.ml
@@ -2,8 +2,8 @@ open Lin_tests_common
 
 module RT_int_domain = Lin_domain.Make(Ref_int_spec)
 module RT_int64_domain = Lin_domain.Make(Ref_int64_spec)
-module CLT_int_domain = Lin_domain.Make(CList_spec_int)
-module CLT_int64_domain = Lin_domain.Make(CList_spec_int64)
+module CLT_int_domain = Lin_domain.Make(CList_spec_int(CList))
+module CLT_int64_domain = Lin_domain.Make(CList_spec_int64(CList))
 
 (** This is a driver of the negative tests over the Domain module *)
 

--- a/src/neg_tests/lin_tests_effect.ml
+++ b/src/neg_tests/lin_tests_effect.ml
@@ -74,9 +74,9 @@ struct
     ]
   end
 
-module CLT_int_effect = Lin_effect.Make(CList_spec_int) [@alert "-experimental"]
+module CLT_int_effect = Lin_effect.Make(CList_spec_int(CList)) [@alert "-experimental"]
 module CLT_int'_effect = Lin_effect.Make(CList_spec_int') [@alert "-experimental"]
-module CLT_int64_effect = Lin_effect.Make(CList_spec_int64) [@alert "-experimental"]
+module CLT_int64_effect = Lin_effect.Make(CList_spec_int64(CList)) [@alert "-experimental"]
 module CLT_int64'_effect = Lin_effect.Make(CList_spec_int64') [@alert "-experimental"]
 
 ;;

--- a/src/neg_tests/lin_tests_thread.ml
+++ b/src/neg_tests/lin_tests_thread.ml
@@ -2,10 +2,10 @@ open Lin_tests_common
 
 (** This is a driver of the negative tests over the Thread module *)
 
-module RT_int_thread = Lin_thread.Make(Ref_int_spec) [@alert "-experimental"]
-module RT_int64_thread = Lin_thread.Make(Ref_int64_spec) [@alert "-experimental"]
-module CLT_int_thread = Lin_thread.Make(CList_spec_int) [@alert "-experimental"]
-module CLT_int64_thread = Lin_thread.Make(CList_spec_int64) [@alert "-experimental"]
+module RT_int_thread = Lin_thread.Make(Ref_int_spec)
+module RT_int64_thread = Lin_thread.Make(Ref_int64_spec)
+module CLT_int_thread = Lin_thread.Make(CList_spec_int)
+module CLT_int64_thread = Lin_thread.Make(CList_spec_int64)
 
 ;;
 QCheck_base_runner.run_tests_main

--- a/src/neg_tests/lin_tests_thread.ml
+++ b/src/neg_tests/lin_tests_thread.ml
@@ -2,15 +2,16 @@ open Lin_tests_common
 
 (** This is a driver of the negative tests over the Thread module *)
 
+module CList_bis = struct include CList let add_node = add_node_thread end
 module RT_int_thread = Lin_thread.Make(Ref_int_spec)
 module RT_int64_thread = Lin_thread.Make(Ref_int64_spec)
-module CLT_int_thread = Lin_thread.Make(CList_spec_int)
-module CLT_int64_thread = Lin_thread.Make(CList_spec_int64)
+module CLT_int_thread = Lin_thread.Make(CList_spec_int(CList_bis))
+module CLT_int64_thread = Lin_thread.Make(CList_spec_int64(CList_bis))
 
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 1000 in
-   [RT_int_thread.lin_test       ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    RT_int64_thread.neg_lin_test ~count:15000 ~name:"Lin ref int64 test with Thread";
-    CLT_int_thread.lin_test      ~count ~name:"Lin CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    CLT_int64_thread.lin_test    ~count ~name:"Lin CList int64 test with Thread"]) (* not triggering context switch, unfortunately *)
+   [RT_int_thread.lin_test        ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+    RT_int64_thread.neg_lin_test  ~count:15000 ~name:"Lin ref int64 test with Thread";
+    CLT_int_thread.neg_lin_test   ~count ~name:"Lin CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+    CLT_int64_thread.neg_lin_test ~count ~name:"Lin CList int64 test with Thread"]) (* not triggering context switch, unfortunately *)

--- a/src/neg_tests/lin_tests_thread.ml
+++ b/src/neg_tests/lin_tests_thread.ml
@@ -16,8 +16,11 @@ let rt_int64_lin_thread_test =
   else
     RT_int64_thread.neg_lin_test  ~count:15000 ~name:"Lin ref int64 test with Thread";
 ;;
-QCheck_base_runner.run_tests_main
-  ([RT_int_thread.lin_test        ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    rt_int64_lin_thread_test;
-    CLT_int_thread.neg_lin_test   ~count ~name:"Lin CList int test with Thread";
-    CLT_int64_thread.neg_lin_test ~count ~name:"Lin CList int64 test with Thread"])
+if Sys.(ocaml_release.major,ocaml_release.minor) < (5,3)
+then Printf.printf "Lin.thread tests disabled on OCaml 5.2 and earlier\n%!"
+else
+  QCheck_base_runner.run_tests_main
+    [RT_int_thread.lin_test        ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+     rt_int64_lin_thread_test;
+     CLT_int_thread.neg_lin_test   ~count ~name:"Lin CList int test with Thread";
+     CLT_int64_thread.neg_lin_test ~count ~name:"Lin CList int64 test with Thread"]

--- a/src/neg_tests/lin_tests_thread.ml
+++ b/src/neg_tests/lin_tests_thread.ml
@@ -2,7 +2,7 @@ open Lin_tests_common
 
 (** This is a driver of the negative tests over the Thread module *)
 
-module CList_bis = struct include CList let add_node = add_node_thread end
+module CList_bis = struct include CList let add_node = add_node_thread end (* moves an allocation to trigger thread unsafety *)
 module RT_int_thread = Lin_thread.Make(Ref_int_spec)
 module RT_int64_thread = Lin_thread.Make(Ref_int64_spec)
 module CLT_int_thread = Lin_thread.Make(CList_spec_int(CList_bis))

--- a/src/neg_tests/lin_tests_thread.ml
+++ b/src/neg_tests/lin_tests_thread.ml
@@ -8,10 +8,16 @@ module RT_int64_thread = Lin_thread.Make(Ref_int64_spec)
 module CLT_int_thread = Lin_thread.Make(CList_spec_int(CList_bis))
 module CLT_int64_thread = Lin_thread.Make(CList_spec_int64(CList_bis))
 
+let count = 1000
+let rt_int64_lin_thread_test =
+  if Sys.backend_type = Sys.Bytecode (* test is considered positive under bytecode *)
+  then
+    RT_int64_thread.lin_test ~count ~name:"Lin ref int64 test with Thread"
+  else
+    RT_int64_thread.neg_lin_test  ~count:15000 ~name:"Lin ref int64 test with Thread";
 ;;
 QCheck_base_runner.run_tests_main
-  (let count = 1000 in
-   [RT_int_thread.lin_test        ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    RT_int64_thread.neg_lin_test  ~count:15000 ~name:"Lin ref int64 test with Thread";
-    CLT_int_thread.neg_lin_test   ~count ~name:"Lin CList int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
-    CLT_int64_thread.neg_lin_test ~count ~name:"Lin CList int64 test with Thread"]) (* not triggering context switch, unfortunately *)
+  ([RT_int_thread.lin_test        ~count ~name:"Lin ref int test with Thread"; (* unboxed, hence no allocations to trigger context switch *)
+    rt_int64_lin_thread_test;
+    CLT_int_thread.neg_lin_test   ~count ~name:"Lin CList int test with Thread";
+    CLT_int64_thread.neg_lin_test ~count ~name:"Lin CList int64 test with Thread"])

--- a/src/neg_tests/stm_tests_clist_domain.ml
+++ b/src/neg_tests/stm_tests_clist_domain.ml
@@ -1,0 +1,8 @@
+open Stm_tests_clist_spec
+module CLT_int_dom = STM_domain.Make(CLConf(Int))
+module CLT_int64_dom = STM_domain.Make(CLConf(Int64))
+;;
+QCheck_base_runner.run_tests_main
+  (let count = 1000 in
+   [CLT_int_dom.neg_agree_test_par   ~count ~name:"STM int CList test parallel";
+    CLT_int64_dom.neg_agree_test_par ~count ~name:"STM int64 CList test parallel"])

--- a/src/neg_tests/stm_tests_clist_domain.ml
+++ b/src/neg_tests/stm_tests_clist_domain.ml
@@ -1,6 +1,6 @@
 open Stm_tests_clist_spec
-module CLT_int_dom = STM_domain.Make(CLConf(Int))
-module CLT_int64_dom = STM_domain.Make(CLConf(Int64))
+module CLT_int_dom = STM_domain.Make(CLConf(CList)(Int))
+module CLT_int64_dom = STM_domain.Make(CLConf(CList)(Int64))
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 1000 in

--- a/src/neg_tests/stm_tests_clist_sequential.ml
+++ b/src/neg_tests/stm_tests_clist_sequential.ml
@@ -1,6 +1,6 @@
 open Stm_tests_clist_spec
-module CLT_int_seq = STM_sequential.Make(CLConf(Int))
-module CLT_int64_seq = STM_sequential.Make(CLConf(Int64))
+module CLT_int_seq = STM_sequential.Make(CLConf(CList)(Int))
+module CLT_int64_seq = STM_sequential.Make(CLConf(CList)(Int64))
 ;;
 QCheck_base_runner.run_tests_main
   (let count = 1000 in

--- a/src/neg_tests/stm_tests_clist_sequential.ml
+++ b/src/neg_tests/stm_tests_clist_sequential.ml
@@ -1,0 +1,8 @@
+open Stm_tests_clist_spec
+module CLT_int_seq = STM_sequential.Make(CLConf(Int))
+module CLT_int64_seq = STM_sequential.Make(CLConf(Int64))
+;;
+QCheck_base_runner.run_tests_main
+  (let count = 1000 in
+   [CLT_int_seq.agree_test   ~count ~name:"STM int CList test sequential";
+    CLT_int64_seq.agree_test ~count ~name:"STM int64 CList test sequential"])

--- a/src/neg_tests/stm_tests_clist_spec.ml
+++ b/src/neg_tests/stm_tests_clist_spec.ml
@@ -1,7 +1,7 @@
 open QCheck
 open STM
 
-(** This is a parallel test of the buggy concurrent list CList *)
+(** A parameterized STM specification of the buggy concurrent list CList *)
 
 module CLConf (T : sig type t val zero : t val of_int : int -> t val to_string : t -> string end) =
 struct
@@ -57,15 +57,3 @@ module Int = struct
   include Stdlib.Int
   let of_int (i:int) : t = i
 end
-
-module CLT_int_seq = STM_sequential.Make(CLConf(Int))
-module CLT_int_dom = STM_domain.Make(CLConf(Int))
-module CLT_int64_seq = STM_sequential.Make(CLConf(Int64))
-module CLT_int64_dom = STM_domain.Make(CLConf(Int64))
-;;
-QCheck_base_runner.run_tests_main
-  (let count = 1000 in
-   [CLT_int_seq.agree_test           ~count ~name:"STM int CList test sequential";
-    CLT_int64_seq.agree_test         ~count ~name:"STM int64 CList test sequential";
-    CLT_int_dom.neg_agree_test_par   ~count ~name:"STM int CList test parallel";
-    CLT_int64_dom.neg_agree_test_par ~count ~name:"STM int64 CList test parallel"])

--- a/src/neg_tests/stm_tests_clist_spec.ml
+++ b/src/neg_tests/stm_tests_clist_spec.ml
@@ -3,7 +3,14 @@ open STM
 
 (** A parameterized STM specification of the buggy concurrent list CList *)
 
-module CLConf (T : sig type t val zero : t val of_int : int -> t val to_string : t -> string end) =
+module CLConf
+    (CList : sig
+       type 'a conc_list
+       val list_init : 'a -> 'a conc_list Atomic.t
+       val add_node: 'a conc_list Atomic.t -> 'a -> bool
+       val member : 'a conc_list Atomic.t -> 'a -> bool
+     end)
+    (T : sig type t val zero : t val of_int : int -> t val to_string : t -> string end) =
 struct
   type cmd =
     | Add_node of T.t

--- a/src/neg_tests/stm_tests_clist_thread.ml
+++ b/src/neg_tests/stm_tests_clist_thread.ml
@@ -3,7 +3,10 @@ module CList_bis = struct include CList let add_node = add_node_thread end (* mo
 module CLT_int_thread = STM_thread.Make(CLConf(CList_bis)(Int))
 module CLT_int64_thread = STM_thread.Make(CLConf(CList_bis)(Int64))
 ;;
-QCheck_base_runner.run_tests_main
-  (let count = 1000 in
-   [CLT_int_thread.neg_agree_test_conc   ~count ~name:"STM int CList test with Thread";
-    CLT_int64_thread.neg_agree_test_conc ~count ~name:"STM int64 CList test with Thread"])
+if Sys.(ocaml_release.major,ocaml_release.minor) < (5,3)
+then Printf.printf "STM.thread CList tests disabled on OCaml 5.2 and earlier\n%!"
+else
+  QCheck_base_runner.run_tests_main
+    (let count = 1000 in
+     [CLT_int_thread.neg_agree_test_conc   ~count ~name:"STM int CList test with Thread";
+      CLT_int64_thread.neg_agree_test_conc ~count ~name:"STM int64 CList test with Thread"])

--- a/src/neg_tests/stm_tests_clist_thread.ml
+++ b/src/neg_tests/stm_tests_clist_thread.ml
@@ -1,5 +1,5 @@
 open Stm_tests_clist_spec
-module CList_bis = struct include CList let add_node = add_node_thread end
+module CList_bis = struct include CList let add_node = add_node_thread end (* moves an allocation to trigger thread unsafety *)
 module CLT_int_thread = STM_thread.Make(CLConf(CList_bis)(Int))
 module CLT_int64_thread = STM_thread.Make(CLConf(CList_bis)(Int64))
 ;;

--- a/src/neg_tests/stm_tests_clist_thread.ml
+++ b/src/neg_tests/stm_tests_clist_thread.ml
@@ -1,0 +1,9 @@
+open Stm_tests_clist_spec
+module CList_bis = struct include CList let add_node = add_node_thread end
+module CLT_int_thread = STM_thread.Make(CLConf(CList_bis)(Int))
+module CLT_int64_thread = STM_thread.Make(CLConf(CList_bis)(Int64))
+;;
+QCheck_base_runner.run_tests_main
+  (let count = 1000 in
+   [CLT_int_thread.neg_agree_test_conc   ~count ~name:"STM int CList test with Thread";
+    CLT_int64_thread.neg_agree_test_conc ~count ~name:"STM int64 CList test with Thread"])

--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -3,11 +3,11 @@ open Stm_tests_spec_ref
 module RT_int   = STM_thread.Make(RConf_int)
 module RT_int64 = STM_thread.Make(RConf_int64)
 ;;
-if Sys.backend_type = Sys.Bytecode
-then
-  Printf.printf "STM ref tests with Thread disabled under bytecode\n\n%!"
-else
 QCheck_base_runner.run_tests_main
   [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
-   RT_int64.neg_agree_test_conc ~count:5000 ~name:"STM int64 ref test with Thread";
+   if Sys.backend_type = Sys.Bytecode (* test is considered positive under bytecode *)
+   then
+     RT_int64.agree_test_conc     ~count:1000 ~name:"STM int64 ref test with Thread"
+   else
+     RT_int64.neg_agree_test_conc ~count:5000 ~name:"STM int64 ref test with Thread";
   ]

--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -1,7 +1,7 @@
 open Stm_tests_spec_ref
 
-module RT_int   = STM_thread.Make(RConf_int)   [@alert "-experimental"]
-module RT_int64 = STM_thread.Make(RConf_int64) [@alert "-experimental"]
+module RT_int   = STM_thread.Make(RConf_int)
+module RT_int64 = STM_thread.Make(RConf_int64)
 ;;
 if Sys.backend_type = Sys.Bytecode
 then

--- a/src/neg_tests/stm_tests_thread_ref.ml
+++ b/src/neg_tests/stm_tests_thread_ref.ml
@@ -3,11 +3,14 @@ open Stm_tests_spec_ref
 module RT_int   = STM_thread.Make(RConf_int)
 module RT_int64 = STM_thread.Make(RConf_int64)
 ;;
-QCheck_base_runner.run_tests_main
-  [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
-   if Sys.backend_type = Sys.Bytecode (* test is considered positive under bytecode *)
-   then
-     RT_int64.agree_test_conc     ~count:1000 ~name:"STM int64 ref test with Thread"
-   else
-     RT_int64.neg_agree_test_conc ~count:5000 ~name:"STM int64 ref test with Thread";
-  ]
+if Sys.(ocaml_release.major,ocaml_release.minor) < (5,3)
+then Printf.printf "STM.thread ref tests disabled on OCaml 5.2 and earlier\n%!"
+else
+  QCheck_base_runner.run_tests_main
+    [RT_int.agree_test_conc       ~count:250  ~name:"STM int ref test with Thread";
+     if Sys.backend_type = Sys.Bytecode (* test is considered positive under bytecode *)
+     then
+       RT_int64.agree_test_conc     ~count:1000 ~name:"STM int64 ref test with Thread"
+     else
+       RT_int64.neg_agree_test_conc ~count:5000 ~name:"STM int64 ref test with Thread";
+    ]

--- a/src/queue/lin_tests.ml
+++ b/src/queue/lin_tests.ml
@@ -18,7 +18,7 @@ module Queue_spec : Lin.Spec = struct
 end
 
 module Lin_queue_domain = Lin_domain.Make(Queue_spec)
-module Lin_queue_thread = Lin_thread.Make(Queue_spec) [@alert "-experimental"]
+module Lin_queue_thread = Lin_thread.Make(Queue_spec)
 
 let () =
   let tests = [

--- a/src/stack/lin_tests.ml
+++ b/src/stack/lin_tests.ml
@@ -18,7 +18,7 @@ module Stack_spec : Lin.Spec = struct
   end
 
 module Stack_domain = Lin_domain.Make(Stack_spec)
-module Stack_thread = Lin_thread.Make(Stack_spec) [@alert "-experimental"]
+module Stack_thread = Lin_thread.Make(Stack_spec)
 
 let () =
   let tests = [


### PR DESCRIPTION
This fixes #338 - or at least gives it a good kick in the right direction.

Both `Lin_thread` and `STM_thread` are currently marked as experimental - and for good reason:
The chance of them triggering unfortunate, error-triggering `Thread` context switches is currently slim.
In hindsight, releasing them earlier - even as `experimental` - was probably premature.

Recall that a `Thread` context switch may happen
- at allocation points and
- at safepoints https://github.com/ocaml/ocaml/blob/trunk/asmcomp/polling.ml

IIUC: 
- The latter is the case for the native code backend.
- The bytecode backend instead uses a `CHECK_SIGNALS` instruction inserted in `while` and `for` loops.
- Both backends utilize a "tick thread" to context switch every 50ms to avoid starvation https://github.com/ocaml/ocaml/blob/trunk/otherlibs/systhreads/st_stubs.c


This PR improves on the situation by utilizing a terrific hack by @edwintorok [in the form of a `Gc.Memprof` callback](https://github.com/ocaml/ocaml/issues/13430):
Upon allocations, with a certain probability, `Memprof` will trigger a callback which can be utilized to trigger an explicit `Thread.yield`.

To get an idea how well this works, I've run stats on our usual {int,int64} x {ref,CList} negative tests, repeating each one 10.000 times, and recording how many of these failed the "interface is `Thread`-safe" property. Since the `Thread` failures are still relatively rare, each of the 10.000 test inputs is `Util.repeat`ed 25 times, to bring up the probability of a failure.

For `CList`, the `Domain`-unsafe `add_node` does not do any allocations in the central "unsafe window", effectively making it `Thread` safe. I've therefore introduced an even worse `add_node_thread` by moving an allocation to this part,
for the purpose of testing...

Each test is run on both 5.3.0, 5.2.0, and 4.14.2 - with only 5.2.0 not having `Gc.Memprof` support: It is available in 4.14 and was restored in 5.3. By running on 5.2 the `Memprof.{start,stop}` calls thereby degrade to essentially noops, and enable an easy comparison with/without the improvement.

#### STM numbers with `Util.repeat 25`:
```
                        5.3.0  5.3.0-bc  5.2.0  5.2.0-bc  4.14.2  4.14.2-bc

int ref STM Thread         0       0        0        0        0       0

int64 ref STM Thread     925       0(!)    34        0      899       0(!)

CList int STM.thread     260     260        0        0      275     268

CList int64 STM.thread   277     274        0        0      274     280
```

#### Lin numbers with `Util.repeat 25`:
```
                        5.3.0  5.3.0-bc  5.2.0  5.2.0-bc  4.14.2  4.14.2-bc

int ref Lin Thread         0       0        0        0        0       0

int64 ref Lin Thread     796       0(!)     1        0      804       0(!)

int CList Lin Thread     161     122        0        0      115     123

int64 CList Lin Thread   124     139        0        1      143     137
```

From the above it is clear that 5.3 and 4.14 works remarkably better than the current version.
Even in bytecode mode this represents a good step forward. However, for some reason, in bytecode mode
both `Lin_thread` and `STM_thread` fail to trigger an `int64 ref` issue. I've not yet figured out why this is the case.


Overview of commits
- The first two commits makes the above change to the two `Lin` and `STM` modes
- Because the fix works relatively well, the next commits removes the previous `experimental` alert attributes
- OCaml 5.0-5.1 raise an exception upon calling `Memprof.{start,stop}` so the 5th commit wraps them in a handler
- The next 2 commits improves documentation
- A bunch of commits adjust the `src/neg_tests` tests to adjust for the improved behaviour
- For anyone interested commits ad1d5e4a45d647a42c73fc09c57f7572afe39da2 and  a4a635cc8f5b32189a61b6a4dce04ebe20c46b72 contain the source for the above stats - I plan to remove these before merging.