### PR TITLE
Disable Lin Bytes test under OCaml 5.2 and earlier

### DIFF
--- a/src/bytes/lin_tests.ml
+++ b/src/bytes/lin_tests.ml
@@ -45,9 +45,16 @@ end
 
 module BT_domain = Lin_domain.Make(BConf)
 module BT_thread = Lin_thread.Make(BConf)
+
+let thread_tail =
+  if Sys.(ocaml_release.major,ocaml_release.minor) < (5,3)
+  then
+    (Printf.printf "Lin.thread Bytes tests disabled on OCaml 5.2 and earlier\n%!"; [])
+  else
+    [ BT_thread.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Thread"; ]
 ;;
-QCheck_base_runner.run_tests_main [
-  BT_domain.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Domain";
-  BT_thread.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Thread";
-  BT_domain.stress_test  ~count:1000 ~name:"Lin Bytes stress test with Domain";
-]
+QCheck_base_runner.run_tests_main (
+  BT_domain.neg_lin_test ~count:5000 ~name:"Lin Bytes test with Domain"::
+  BT_domain.stress_test  ~count:1000 ~name:"Lin Bytes stress test with Domain"::
+  thread_tail
+)


### PR DESCRIPTION
The weekly runs this morning caused all 5.2.0 runs to fail the Lin Bytes test.

This was an omission from #546:
> The new improved ™️ Thread mode utilizes Gc.Memprof support to trigger context switching. 5.3 restored Memprof, which means the thread test works well there and on trunk - both tested by CI on PRs.
I tested locally on 5.2 at some point and then forgot about it again. Given the above, I think the Lin Thread-mode test of Bytes should just be disabled on 5.2 and earlier.

This PR does exactly that.