### PR TITLE
Remove dune pins again

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: 2de53980efa731eacf5475139d9a5a218f9752a0
+          ref: 3.18.0
           path: dune
         if: steps.cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -42,7 +42,6 @@ jobs:
 
       - name: Test installation of the OPAM packages
         run: |
-          opam pin -n add https://github.com/ocaml/dune.git\#2de53980efa731eacf5475139d9a5a218f9752a0
           opam install --with-test ./qcheck-multicoretests-util.opam ./qcheck-lin.opam ./qcheck-stm.opam
 
       - name: Show configuration


### PR DESCRIPTION
Fixes #539

`dune.3.18.0` is now available on the opam repo.

This rolls back the pinning needed in #531 and #538.