### PR TITLE
Remove workaround for trunk-incompatible dune

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -128,8 +128,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: d579f22a0ce4e237bc38127e0ec2234b3c87ddea
-          # ^ TEMPORARY: Follow change for signals in trunk
+          ref: 3.18.2
           path: dune
         if: steps.cache.outputs.cache-hit != 'true'
 

--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - name: Pin dune for trunk
-        run: |
-          opam pin add -n dune 'https://github.com/ocaml/dune.git#d579f22a0ce4e237bc38127e0ec2234b3c87ddea'
-        if: matrix.ocaml-compiler == 'ocaml-variants.5.4.0+trunk'
-
       - name: Test installation of the OPAM packages
         run: |
           opam install --with-test ./qcheck-multicoretests-util.opam ./qcheck-lin.opam ./qcheck-stm.opam


### PR DESCRIPTION
This PR removes the workaround for a trunk-incompatible dune from #550, now that a compatible dune.3.18.2 has been released.