### PR TITLE
Reenable Lin Dynlink test under Windows

### DIFF
--- a/src/dynlink/lin_tests.ml
+++ b/src/dynlink/lin_tests.ml
@@ -31,9 +31,9 @@ end
 module DynT = Lin_domain.Make(DynConf)
 
 let _ =
-  if Sys.win32 || Sys.cygwin
-  then
-    Printf.printf "Lin Dynlink tests disabled under Windows\n\n%!"
+  if (Sys.win32 || Sys.cygwin) && Sys.(ocaml_release.major,ocaml_release.minor) < (5,4)
+  then (* Parallel Dynlink usage under Cygwin+MinGW is unsafe https://github.com/ocaml/ocaml/issues/13046 *)
+    Printf.printf "Lin Dynlink tests disabled on OCaml < 5.4 under Windows\n\n%!"
   else
     QCheck_base_runner.run_tests_main [
       DynT.neg_lin_test ~count:100  ~name:"negative Lin Dynlink test with Domain";


### PR DESCRIPTION
This PR reenables the `Lin` `Dynlink` test under Windows now that https://github.com/ocaml/ocaml/pull/14032 has been merged.

With our `opam`-free test setup the flexdll.0.44 release to the opam repo is not enough.
Since the above PR has been cherry-picked to the 5.4 branch too, this PR reenables the test for > 5.3
and thus avoids inserting any `git` sub-module update workarounds... :slightly_smiling_face: 

Fixes #488