### PR TITLE
STM Weak test re-revision

### DIFF
--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -144,7 +144,7 @@ let postcond c (s:data list) res = match c, res with
   | Find d, Res ((Result (Int64,Exn),_),r) ->
     r = Error Not_found || (List.mem d s && r = Ok d)
   | Find_opt d, Res ((Result (Option Int64,Exn),_),r) ->
-    r = Ok None || r = Ok (Some d)
+    r = Ok None || (List.mem d s && r = Ok (Some d))
   | Find_all d, Res ((Result (List Int64,Exn),_),r) ->
     (match r with
      | Error _ -> false

--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -62,8 +62,8 @@ let arb_cmd s =
   QCheck.make ~print:show_cmd (*~shrink:shrink_cmd*)
     Gen.(frequency
            [ 1,return Clear;
-             1,map (fun d -> Merge d) data_gen;
-             1,map (fun d -> Add d) data_gen;
+             2,map (fun d -> Merge d) data_gen;
+             2,map (fun d -> Add d) data_gen;
              1,map (fun d -> Remove d) data_gen;
              1,map (fun d -> Find d) data_gen;
              1,map (fun d -> Find_opt d) data_gen;

--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -135,25 +135,21 @@ let postcond c (s:data list) res = match c, res with
   | Clear, Res ((Unit,_),())  -> true
   | Merge d, Res ((Result (Int64,Exn),_),r) ->
     (match r with
-     | Error e -> e = Invalid_argument "index out of bounds"
+     | Error _ -> false
      | Ok r -> if List.mem d s then r = d else r == d)
   | Add _, Res ((Result (Unit,Exn),_),r) ->
-    r = Error (Invalid_argument "index out of bounds") || r = Ok ()
+    r = Ok ()
   | Remove _, Res ((Result (Unit,Exn),_),r) ->
-    r = Error (Invalid_argument "index out of bounds") || r = Ok ()
+    r = Ok ()
   | Find d, Res ((Result (Int64,Exn),_),r) ->
-    r = Error (Invalid_argument "index out of bounds") ||
-    r = Error Not_found ||
-    (List.mem d s && r = Ok d)
+    r = Error Not_found || (List.mem d s && r = Ok d)
   | Find_opt d, Res ((Result (Option Int64,Exn),_),r) ->
-    r = Error (Invalid_argument "index out of bounds") ||
     r = Ok None || r = Ok (Some d)
   | Find_all d, Res ((Result (List Int64,Exn),_),r) ->
     (match r with
-     | Error e -> e = Invalid_argument "index out of bounds"
+     | Error _ -> false
      | Ok r -> List.for_all (fun d' -> d' = d) r)
   | Mem d, Res ((Result (Bool,Exn),_),r) ->
-    r = Error (Invalid_argument "index out of bounds") ||
     r = Ok (List.mem d s) || r = Ok false
   | Count, Res ((Int,_),r) ->
     r <= List.length s

--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -113,13 +113,13 @@ let tup6 spec_a spec_b spec_c spec_d spec_e spec_f =
 
 let run c hs = match c with
   | Clear      -> Res (unit, WHS.clear hs)
-  | Merge d    -> Res (result string exn, protect (WHS.merge hs) d)
-  | Add d      -> Res (result unit exn, protect (WHS.add hs) d)
-  | Remove d   -> Res (result unit exn, protect (WHS.remove hs) d)
-  | Find d     -> Res (result string exn, protect (WHS.find hs) d)
-  | Find_opt d -> Res (result (option string) exn, protect (WHS.find_opt hs) d)
-  | Find_all d -> Res (result (list string) exn, protect (WHS.find_all hs) d)
-  | Mem d      -> Res (result bool exn, protect (WHS.mem hs) d)
+  | Merge d    -> Res (result string exn, protect (fun () -> WHS.merge hs d) ())
+  | Add d      -> Res (result unit exn, protect (fun () -> WHS.add hs d) ())
+  | Remove d   -> Res (result unit exn, protect (fun () -> WHS.remove hs d) ())
+  | Find d     -> Res (result string exn, protect (fun () -> WHS.find hs d) ())
+  | Find_opt d -> Res (result (option string) exn, protect (fun () -> WHS.find_opt hs d) ())
+  | Find_all d -> Res (result (list string) exn, protect (fun () -> WHS.find_all hs d) ())
+  | Mem d      -> Res (result bool exn, protect (fun () -> WHS.mem hs d) ())
   | Count      -> Res (int, WHS.count hs)
   | Stats      -> Res (tup6 int int int int int int, WHS.stats hs)
 

--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -55,8 +55,7 @@ let _shrink_cmd c = match c with
   | Stats -> Iter.empty
 
 let arb_cmd s =
-  let len_gen = Gen.(map (fun f -> int_of_float (0.4 +. f)) (exponential 9.)) in
-  let string_gen = Gen.(string_size ~gen:printable len_gen) in
+  let string_gen = Gen.(string_small_of printable) in
   let data_gen = match s with
     | [] -> string_gen
     | _::_ -> Gen.(oneof [oneofl s; string_gen]) in

--- a/src/weak/stm_tests_hashset_spec.ml
+++ b/src/weak/stm_tests_hashset_spec.ml
@@ -96,8 +96,7 @@ let weak_size = 16
 let init_sut () = Gc.minor (); WHS.create weak_size
 let cleanup _   = ()
 
-let precond c _s = match c with
-  | _ -> true
+let precond _c _s = true
 
 type _ ty += Tup6 : 'a ty * 'b ty * 'c ty * 'd ty * 'e ty * 'f ty -> ('a * 'b * 'c * 'd * 'e * 'f) ty
 

--- a/src/weak/stm_tests_weak_spec.ml
+++ b/src/weak/stm_tests_weak_spec.ml
@@ -72,8 +72,7 @@ let next_state c s = match c with
 let init_sut () = Gc.minor (); Weak.create weak_size
 let cleanup _   = ()
 
-let precond c _s = match c with
-  | _ -> true
+let precond _c _s = true
 
 let run c a = match c with
   | Length       -> Res (int, Weak.length a)

--- a/src/weak/stm_tests_weak_spec.ml
+++ b/src/weak/stm_tests_weak_spec.ml
@@ -52,7 +52,7 @@ let arb_cmd s =
              2,map3 (fun i len c -> Fill (i,len,c)) int_gen int_gen (option data_gen); (* hack: reusing int_gen for length *)
            ])
 
-let weak_size = 16
+let weak_size = 10
 
 let init_state  = List.init weak_size (fun _ -> None)
 

--- a/src/weak/stm_tests_weak_spec.ml
+++ b/src/weak/stm_tests_weak_spec.ml
@@ -92,15 +92,15 @@ let postcond c (s:int64 option list) res = match c, res with
   | Get i, Res ((Result (Option Int64,Exn),_), r) ->
     if i < 0 || i >= List.length s
     then r = Error (Invalid_argument "Weak.get")
-    else r = Ok (List.nth s i)
+    else r = Ok None || r = Ok (List.nth s i)
   | Get_copy i, Res ((Result (Option Int64,Exn),_), r) ->
     if i < 0 || i >= List.length s
     then r = Error (Invalid_argument "Weak.get_copy")
-    else r = Ok (List.nth s i)
+    else r = Ok None || r = Ok (List.nth s i)
   | Check i, Res ((Result (Bool,Exn),_),r) ->
     if i < 0 || i >= List.length s
     then r = Error (Invalid_argument "Weak.check")
-    else r = Ok (None <> List.nth s i)
+    else r = Ok false || r = Ok (None <> List.nth s i)
   | Fill (i,l,_), Res ((Result (Unit,Exn),_), r) ->
     if i < 0 || l < 0 || i+l > List.length s
     then r = Error (Invalid_argument "Weak.fill")

--- a/src/weak/stm_tests_weak_spec.ml
+++ b/src/weak/stm_tests_weak_spec.ml
@@ -49,7 +49,7 @@ let arb_cmd s =
              2,map (fun i -> Get i) int_gen;
              2,map (fun i -> Get_copy i) int_gen;
              2,map (fun i -> Check i) int_gen;
-             1,map3 (fun i len c -> Fill (i,len,c)) int_gen int_gen (option data_gen); (* hack: reusing int_gen for length *)
+             2,map3 (fun i len c -> Fill (i,len,c)) int_gen int_gen (option data_gen); (* hack: reusing int_gen for length *)
            ])
 
 let weak_size = 16

--- a/src/weak/stm_tests_weak_spec.ml
+++ b/src/weak/stm_tests_weak_spec.ml
@@ -77,11 +77,11 @@ let precond c _s = match c with
 
 let run c a = match c with
   | Length       -> Res (int, Weak.length a)
-  | Set (i,c)    -> Res (result unit exn, protect (Weak.set a i) c)
-  | Get i        -> Res (result (option string) exn, protect (Weak.get a) i)
-  | Get_copy i   -> Res (result (option string) exn, protect (Weak.get_copy a) i)
-  | Check i      -> Res (result bool exn, protect (Weak.check a) i)
-  | Fill (i,l,c) -> Res (result unit exn, protect (Weak.fill a i l) c)
+  | Set (i,c)    -> Res (result unit exn, protect (fun () -> Weak.set a i c) ())
+  | Get i        -> Res (result (option string) exn, protect (fun () -> Weak.get a i) ())
+  | Get_copy i   -> Res (result (option string) exn, protect (fun () -> Weak.get_copy a i) ())
+  | Check i      -> Res (result bool exn, protect (fun () -> Weak.check a i) ())
+  | Fill (i,l,c) -> Res (result unit exn, protect (fun () -> Weak.fill a i l c) ())
 
 let postcond c (s:state) res = match c, res with
   | Length, Res ((Int,_),i) -> i = List.length s


### PR DESCRIPTION
I recently had a fresh look at the weak array and weak hash set STM tests, and discovered a couple of things.
This PR is the outcome.

The weak array and weak hash set test originated in #214.
They've since been tweaked, e.g., in #365 which among other things switched to `int64` data for the weak hash sets test,
arguing that this was faster to shrink. As we no longer shrink the `data` this argument no longer holds.
Furthermore, the tests triggered crashes in the past with `string` `data` in #283, which was caused by a combination of race conditions and variable length memory records. This speaks for reverting and using `string`s for both tests. I've confirmed that both parallel tests can trigger segfaults on an older version (OCaml 5.0.0~alpha1) with these changes.

The PR also
- revises the post-conditions slightly,
- adjusts the frequencies slightly to skew them towards making additions, and
- cleans up the `protect` calls with thunks, rather than the current missing-last-argument-closure