### PR TITLE
Rework GADT index types to get Lin compiling on trunk again

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## NEXT RELEASE
+
+- #560: Change `Lin.{constructible,deconstructible}` from an empty variant type
+        to an abstract type to get `Lin` compiling on `5.5.0+trunk` again, due
+        to https://github.com/ocaml/ocaml/pull/13994 removing special handling
+        of abstract and empty variants defined in the current module.
+
 ## 0.8
 
 - #540: Significantly increase the probability of context switching in `Lin_thread`

--- a/lib/lin.ml
+++ b/lib/lin.ml
@@ -141,11 +141,11 @@ end
 
 (* Type-representing values *)
 
-type constructible = |
-type deconstructible = |
+type constructible = private Constructible [@@ocaml.warning "-37"]
+type deconstructible = private Deconstructible [@@ocaml.warning "-37"]
 
-type combinable
-type noncombinable
+type combinable = private Combinable [@@ocaml.warning "-37"]
+type noncombinable = private Noncombinable [@@ocaml.warning "-37"]
 
 type (_,_,_,_) ty =
   | Gen : 'a QCheck.arbitrary * ('a -> string) -> ('a, constructible, 's, combinable) ty

--- a/lib/lin.mli
+++ b/lib/lin.mli
@@ -57,10 +57,10 @@ end
 
 (** {1 Type-representing values} *)
 
-type constructible = |
+type constructible
 (** Type definition to denote whether a described type can be generated *)
 
-type deconstructible = |
+type deconstructible
 (** Type definition to denote whether a described type can be deconstructed,
     i.e., tested for equality. *)
 


### PR DESCRIPTION
Fixes #559 

ATM this changes two empty variant types in the interface, which is a bit annoying... :thinking: 