### PR TITLE
Bump QCheck to 0.26 (and fix float comparisons)

### DIFF
--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: c-cube/qcheck
-          ref: v0.25
+          ref: v0.26
           path: multicoretests/qcheck
 
       - name: Pre-Setup

--- a/src/floatarray/stm_tests.ml
+++ b/src/floatarray/stm_tests.ml
@@ -108,7 +108,7 @@ struct
     | Get i, Res ((Result (Float,Exn),_), r) ->
       if i < 0 || i >= List.length s
       then r = Error (Invalid_argument "index out of bounds")
-      else r = Ok (List.nth s i)
+      else Result.equal ~ok:Float.equal ~error:(=) r (Ok (List.nth s i))
     | Set (i,_), Res ((Result (Unit,Exn),_), r) ->
       if i < 0 || i >= List.length s
       then r = Error (Invalid_argument "index out of bounds")
@@ -128,7 +128,7 @@ struct
     | To_list, Res ((List Float,_),fs) -> List.equal Float.equal fs s
     | Mem f, Res ((Bool,_),r) -> r = List.mem f s
     | Sort, Res ((Unit,_),r) -> r = ()
-    | To_seq, Res ((Seq Float,_),r) -> Seq.equal (=) r (List.to_seq s)
+    | To_seq, Res ((Seq Float,_),r) -> Seq.equal Float.equal r (List.to_seq s)
     | _, _ -> false
 end
 


### PR DESCRIPTION
The QCheck 0.26 release https://github.com/c-cube/qcheck/releases/tag/v0.26 changes the distribution of the `float` generator to avoid blind spots: c-cube/qcheck#350.

As we have a couple of tests with `float`s this PR bumps the QCheck version to see if we've missed anything `float`-related.