### PR TITLE
Adjust the exception matched in domain/domain_spawntree.ml

### DIFF
--- a/src/domain/domain_spawntree.ml
+++ b/src/domain/domain_spawntree.ml
@@ -89,7 +89,7 @@ let t ~max_height ~max_degree = Test.make
             Atomic.get a = interp 0 c
           with
           | Failure s ->
-            if s = "failed to allocate domain"
+            if s = "failed to allocate domain" || s = "failed to allocate domain: domain_create"
             then true
             else (Printf.printf "Failure \"%s\"\n%!" s; false)
        ))


### PR DESCRIPTION
The merge to `main` of the 0.10 release branch triggered a new error on `trunk`, e.g. on macOS ARM64:
https://github.com/ocaml-multicore/multicoretests/actions/runs/18315096994/job/52153110419
```
random seed: 380531517
generated error fail pass / total     time test name

[ ]    0    0    0    0 /  100     0.0s domain_spawntree - with AtomicFailure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100    60.7s domain_spawntree - with Atomic (shrinking:    8.0004)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   121.2s domain_spawntree - with Atomic (shrinking:   10.0009)Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   182.2s domain_spawntree - with Atomic (shrinking:   11.0013)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   242.6s domain_spawntree - with Atomic (shrinking:   14.0005)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   303.7s domain_spawntree - with Atomic (shrinking:   18.0008)
[ ]   98    0    0   98 /  100   365.6s domain_spawntree - with Atomic (shrinking:   18.0037)
[ ]   98    0    0   98 /  100   426.6s domain_spawntree - with Atomic (shrinking:   18.0066)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   487.8s domain_spawntree - with Atomic (shrinking:   22.0009)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   548.1s domain_spawntree - with Atomic (shrinking:   24.0006)Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   608.1s domain_spawntree - with Atomic (shrinking:   25.0014)Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   668.5s domain_spawntree - with Atomic (shrinking:   26.0032)
[ ]   98    0    0   98 /  100   730.1s domain_spawntree - with Atomic (shrinking:   26.0067)Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   790.7s domain_spawntree - with Atomic (shrinking:   27.0034)Failure "failed to allocate domain: domain_create"
Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100   852.2s domain_spawntree - with Atomic (shrinking:   29.0012)
[ ]   98    0    0   98 /  100   913.5s domain_spawntree - with Atomic (shrinking:   29.0049)
[ ]   98    0    0   98 /  100   974.4s domain_spawntree - with Atomic (shrinking:   29.0086)Failure "failed to allocate domain: domain_create"

[ ]   98    0    0   98 /  100  1035.3s domain_spawntree - with Atomic (shrinking:   30.0021)
[ ]   98    0    0   98 /  100  1096.6s domain_spawntree - with Atomic (shrinking:   30.0060)
[ ]   98    0    0   98 /  100  1158.0s domain_spawntree - with Atomic (shrinking:   30.0100)
[ ]   98    0    0   98 /  100  1219.0s domain_spawntree - with Atomic (shrinking:   30.0140)
[ ]   98    0    0   98 /  100  1279.2s domain_spawntree - with Atomic (shrinking:   30.0178)
[ ]   98    0    0   98 /  100  1340.7s domain_spawntree - with Atomic (shrinking:   30.0217)
[ ]   98    0    0   98 /  100  1400.9s domain_spawntree - with Atomic (shrinking:   30.0256)
[✗]   99    0    1   98 /  100  1452.0s domain_spawntree - with Atomic

--- Failure --------------------------------------------------------------------

Test domain_spawntree - with Atomic failed (30 shrink steps):

Spawn [Incr; Incr; Spawn [Incr; Incr... (truncated)
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
File "src/domain/dune", line 14, characters 7-23:
14 |  (name domain_spawntree)
            ^^^^^^^^^^^^^^^^
(cd _build/default/src/domain && ./domain_spawntree.exe --verbose)
Command exited with code 1.
```

This is because the `domain_spawntree.ml` test matches on the exception name in case of failure (generally a bad idea, but OK'ish when testing a runtime system and Stdlib against regressions), and the just merged https://github.com/ocaml/ocaml/pull/12410 changed the error message slightly.

This PR therefore updates the `Failure` exception message check.